### PR TITLE
Remove eventloop and curl deadlock

### DIFF
--- a/examples/benchmark_simple.cpp
+++ b/examples/benchmark_simple.cpp
@@ -32,7 +32,10 @@ public:
         }
 
         // And request again!
-        GetEventLoop().StartRequest(std::move(request));
+        if(!GetEventLoop().StartRequest(std::move(request)))
+        {
+            std::cerr << "Event loop is no longer accepting requests.\n";
+        }
     }
 };
 


### PR DESCRIPTION
The examples/benchmark_simple.cpp was causing the libuv
event loop thread to deadlock when grabbing new requests.
This was due to it calling the curl_multi_add_handle()
function while holding the m_pending_requests_lock.