### PR TITLE
Allow for custom static libcurl/libc-ares/libssl/libcrypto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ project(lifthttp CXX)
 
 message(${CMAKE_CXX_COMPILER_ID})
 
+set(LIBSSL "" CACHE STRING "User specified libsss static location.")
+set(LIBCRYPTO "" CACHE STRING "User specificed libcrypto static location.")
+set(LIBCURL "curl" CACHE STRING "User specified libcurl static location.")
+set(LIBCARES "" CACHE STRING "User specified libcares static location.")
+
+message("LIBCURL = ${LIBCURL}")
+
 set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
@@ -38,8 +45,13 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/in
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
     uv
-    curl
+    ${LIBSSL}
+    ${LIBCRYPTO}
+    ${LIBCURL}
+    ${LIBCARES}
     pthread
+    z
+    dl
 )
 
 include(examples/CMakeLists.txt)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,49 +5,49 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
 
 ### synch_simple ###
 set(SYNCH_SIMPLE_SOURCE_FILES
-        examples/synch_simple.cpp
+    examples/synch_simple.cpp
 )
 add_executable(synch_simple ${SYNCH_SIMPLE_SOURCE_FILES})
-target_link_libraries(synch_simple PRIVATE lifthttp uv curl)
+target_link_libraries(synch_simple PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### async_simple ###
 set(ASYNC_SIMPLE_SOURCE_FILES
     examples/async_simple.cpp
 )
 add_executable(async_simple ${ASYNC_SIMPLE_SOURCE_FILES})
-target_link_libraries(async_simple PRIVATE lifthttp uv curl)
+target_link_libraries(async_simple PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### async_batch_requests ###
 set(ASYNC_BATCH_REQUESTS_SOURCE_FILES
         examples/async_batch_requests.cpp
 )
 add_executable(async_batch_requests ${ASYNC_BATCH_REQUESTS_SOURCE_FILES})
-target_link_libraries(async_batch_requests PRIVATE lifthttp uv curl)
+target_link_libraries(async_batch_requests PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### query_builder ###
 set(QUERY_BUILDER_SOURCE_FILES
     examples/query_builder.cpp
 )
 add_executable(query_builder ${QUERY_BUILDER_SOURCE_FILES})
-target_link_libraries(query_builder PRIVATE lifthttp uv curl)
+target_link_libraries(query_builder PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### request_headers ###
 set(REQUEST_HEADERS_SIMPLE_SOURCE_FILES
     examples/request_headers_simple.cpp
 )
 add_executable(request_headers_simple ${REQUEST_HEADERS_SIMPLE_SOURCE_FILES})
-target_link_libraries(request_headers_simple PRIVATE lifthttp uv curl)
+target_link_libraries(request_headers_simple PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### benchmark_simple ###
 set(BENCHMARK_SIMPLE_SOURCE_FILES
     examples/benchmark_simple.cpp
 )
 add_executable(benchmark_simple ${BENCHMARK_SIMPLE_SOURCE_FILES})
-target_link_libraries(benchmark_simple PRIVATE lifthttp uv curl)
+target_link_libraries(benchmark_simple PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)
 
 ### user_data ###
 set(USER_DATA_SOURCE_FILES
     examples/user_data.cpp
 )
 add_executable(user_data ${USER_DATA_SOURCE_FILES})
-target_link_libraries(user_data PRIVATE lifthttp uv curl)
+target_link_libraries(user_data PRIVATE lifthttp uv ${LIBSSL} ${LIBCRYPTO} ${LIBCURL} ${LIBCARES} z dl)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,5 +14,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE lifthttp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
     uv
-    curl
+    ${LIBSSL}
+    ${LIBCRYPTO}
+    ${LIBCURL}
+    ${LIBCARES}
+    z
+    dl
 )


### PR DESCRIPTION
These are passed through CMAKE parameters:
  -DLIBCURL:STRING=/path/to/libcurl.a
  -DLIBCARES:STRING=/path/to/libcares.a
  -DLIBSSL:STRING=/path/to/libssl.a
  -DLIBCRYPTO:STRING=/path/to/libcrypto.a

Custom header file locations may be passed via:

  -DCMAKE_CXX_FLAGS=-isystem\ /path/to/libcurl/include