### PR TITLE
Remove max bytes argument from Produce

### DIFF
--- a/examples/async_simple_max_bytes.cpp
+++ b/examples/async_simple_max_bytes.cpp
@@ -66,7 +66,8 @@ int main(int argc, char* argv[])
     {
         std::cout << "Requesting " << url << " to download max byes of : " << bytes_to_download << std::endl;
 
-        lift::Request request = request_pool.Produce(url, on_complete, 0ms, bytes_to_download);
+        lift::Request request = request_pool.Produce(url, on_complete, 0ms);
+        request->SetMaxDownloadBytes(bytes_to_download);
         event_loop.StartRequest(std::move(request));
         timeout += 550ms;
         bytes_to_download += 1000;

--- a/inc/lift/RequestPool.h
+++ b/inc/lift/RequestPool.h
@@ -60,14 +60,12 @@ public:
      * @param url The url of the Request.
      * @param on_complete_handler The on completion callback handler for this request.
      * @param timeout The timeout of the request.
-     * @param max_download_bytes The maximum number of bytes to download (-1 means download everything).
      * @return A Request object setup for the URL + Timeout.
      */
     auto Produce(
         const std::string& url,
         OnCompleteHandler on_complete_handler,
-        std::chrono::milliseconds timeout,
-        ssize_t max_download_bytes = -1
+        std::chrono::milliseconds timeout
     ) -> Request;
 
 private:

--- a/src/RequestPool.cpp
+++ b/src/RequestPool.cpp
@@ -40,8 +40,7 @@ auto RequestPool::Produce(
 auto RequestPool::Produce(
     const std::string& url,
     OnCompleteHandler on_complete_handler,
-    std::chrono::milliseconds timeout,
-    ssize_t max_download_bytes
+    std::chrono::milliseconds timeout
 ) -> Request
 {
     m_lock.lock();
@@ -58,8 +57,7 @@ auto RequestPool::Produce(
                 *this,
                 m_curl_pool->Produce(),
                 *m_curl_pool,
-                on_complete_handler,
-                max_download_bytes
+                on_complete_handler
             )
         );
 
@@ -74,7 +72,6 @@ auto RequestPool::Produce(
         request_handle_ptr->SetOnCompleteHandler(on_complete_handler);
         request_handle_ptr->SetUrl(url);
         request_handle_ptr->SetTimeout(timeout);
-        request_handle_ptr->SetMaxDownloadBytes(max_download_bytes);
 
         return Request(this, std::move(request_handle_ptr));
     }


### PR DESCRIPTION
To set max download bytes, call SetMaxDownloadByte on the request
returned from Produce

  modified:   examples/async_simple_max_bytes.cpp
  modified:   inc/lift/RequestPool.h
  modified:   src/RequestPool.cpp