### PR TITLE
Change the RequestHandle header append to use += instead of append fo…

### DIFF
--- a/src/RequestHandle.cpp
+++ b/src/RequestHandle.cpp
@@ -235,7 +235,7 @@ auto RequestHandle::AddHeader(
         m_request_headers.reserve(capacity);
     }
 
-    const char* start = m_request_headers.data() + m_request_headers.size();
+    const char* start = m_request_headers.data() + m_request_headers.length();
 
     m_request_headers.append(name.data(), name.length());
     m_request_headers.append(": ");
@@ -243,7 +243,7 @@ auto RequestHandle::AddHeader(
     {
         m_request_headers.append(value.data(), value.length());
     }
-    m_request_headers.append("\0"); // curl expects null byte
+    m_request_headers += '\0'; // curl expects null byte, do not use string.append, it ignores null terminators!
 
     std::string_view full_header(start, header_len - 1); // subtract off the null byte
     m_request_headers_idx.emplace_back(full_header);


### PR DESCRIPTION
…r null byte

append() will ignore appending any null terminating bytes (event if it is the only
thing in the string being appended).  Using += with '\n' appends an 'int' value
and correctly appends the null byte into the string.  This is important for when
the curl_slist of headers is generated from m_request_headers buffer otherwise
all the headers run on until the last header.. oops.