### PR TITLE
Add new Methods to change CURLOPTs for SSL

### DIFF
--- a/inc/lift/Request.h
+++ b/inc/lift/Request.h
@@ -231,6 +231,12 @@ public:
     auto GetNumConnects() const -> uint64_t;
     
     /**
+     * Set the verify behavior of the CURLOPT_SSL_VERIFYPEER and CURLOPT_SSL_VERIFYHOST on the curl_handle
+     * @param verify the verify value to set the CURLOPT_SSL_VERIFYPEER and CURLOPT_SSL_VERIFYHOST options to
+     */
+    auto SetVerifySSLHostAndPeer(long verify) -> void;
+
+    /**
      * Resets the request to be re-used.  This will clear everything on the request.
      */
     auto Reset() -> void;

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -332,6 +332,12 @@ auto Request::GetCompletionStatus() const -> RequestStatus
     return m_status_code;
 }
 
+auto Request::SetVerifySSLHostAndPeer(long verify) -> void
+{
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYPEER, verify);
+    curl_easy_setopt(m_curl_handle, CURLOPT_SSL_VERIFYHOST, verify);
+}
+
 auto Request::Reset() -> void
 {
     m_url = std::string_view {};


### PR DESCRIPTION
Provide new method for the Request Object to change the CURLOPT_SSL_VERIFYHOST and CURLOPT_SSL_VERIFYPEER values

	-Useful when particular apps are not concerned with verifying the host and peer in ssl connections
		-For example when connecting to internal apps that may not have legitamite certs.