### PR TITLE
Vector curl slist optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ liblifthttp - Safe Easy to use C++17 HTTP client library.
 
 You're using curl? Do you even lift?
 
-Copyright (c) 2017-2020, Josh Baldwin
-
 https://github.com/jbaldwin/liblifthttp
 
-**liblifthttp** is an HTTP C++17 client library that provides an easy to use API for both synchronous _and_ asynchronous requests.  It is built upon the rock solid libcurl and libuv libraries.
+**liblifthttp** is a C++17 HTTP client library that provides an easy to use API for both synchronous _and_ asynchronous requests.  It is built upon the rock solid libcurl and libuv libraries.
 
 **liblifthttp** is licensed under the Apache 2.0 license.
 
@@ -193,3 +191,5 @@ ctest -V
 ## Support
 
 File bug reports, feature requests and questions using [GitHub Issues](https://github.com/jbaldwin/liblifthttp/issues)
+
+Copyright © 2017-2020, Josh Baldwin

--- a/inc/lift/Request.hpp
+++ b/inc/lift/Request.hpp
@@ -297,7 +297,7 @@ private:
     /// The request headers index.  Used to generate the curl slist.
     std::vector<HeaderView> m_request_headers_idx{};
     /// The curl request headers.
-    curl_slist* m_curl_request_headers{ nullptr };
+    std::vector<curl_slist> m_curl_request_headers{};
     /// Have the headers been committed into cURL?
     bool m_headers_committed{ false };
     /// The request data if any. Mutually exclusive with m_mime_handle.

--- a/test/SyncRequestTest.hpp
+++ b/test/SyncRequestTest.hpp
@@ -50,3 +50,52 @@ TEST_CASE("Synchrnous custom headers")
         }
     }
 }
+
+TEST_CASE("Multiple headers added")
+{
+    lift::RequestPool rp{};
+    auto r = rp.Produce("http://localhost:80/");
+    r->AddHeader("Connection", "keep-alive");
+    r->AddHeader("x-custom-header-1", "value1");
+    r->AddHeader("x-custom-header-2", "value2");
+    r->AddHeader("x-herp-derp", "merp");
+    r->AddHeader("x-420", "blazeit");
+
+    r->Perform();
+
+    REQUIRE(r->GetCompletionStatus() == lift::RequestStatus::SUCCESS);
+    REQUIRE(r->GetResponseStatusCode() == lift::http::StatusCode::HTTP_200_OK);
+
+    std::size_t count_found = 0;
+
+    for(const auto& header : r->GetRequestHeaders())
+    {
+        if(header.GetName() == "Connection")
+        {
+            REQUIRE(header.GetValue() == "keep-alive");
+            ++count_found;
+        }
+        else if(header.GetName() == "x-custom-header-1")
+        {
+            REQUIRE(header.GetValue() == "value1");
+            ++count_found;
+        }
+        else if(header.GetName() == "x-custom-header-2")
+        {
+            REQUIRE(header.GetValue() == "value2");
+            ++count_found;
+        }
+        else if(header.GetName() == "x-herp-derp")
+        {
+            REQUIRE(header.GetValue() == "merp");
+            ++count_found;
+        }
+        else if(header.GetName() == "x-420")
+        {
+            REQUIRE(header.GetValue() == "blazeit");
+            ++count_found;
+        }
+    }
+
+    REQUIRE(count_found == 5);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -5,9 +5,9 @@
 
 static lift::GlobalScopeInitializer g_lift_gsi{};
 
+#include "AsyncRequestTest.hpp"
 #include "EscapeTest.hpp"
 #include "QueryBuilderTest.hpp"
 #include "SyncRequestTest.hpp"
-#include "AsyncRequestTest.hpp"
 #include "TransferProgressRequest.hpp"
 #include "UserDataRequestTest.hpp"


### PR DESCRIPTION
Previously curl_slist_append() was being called for every header, curl will allocate a curl_slist* each time this function is called as a singly linked list.

This optimization now creates a vector<curl_slist> and manually link the items together so curl thinks its doing the work, but in reality it is now one contiguous allocation.