### PR TITLE
Fix data race in UserData tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,20 @@ Note in this final test the box is fully utilized and is competing for CPU time 
       3,781,388 requests in 30s
       Req/sec: 126,046
 
-## Testing
+## Contributing and Testing
 
-This project has a [CircleCI](https://circleci.com/) implementation to compile and run tests
-against Ubuntu g++ and clang++.  More distros might be added in the future.
+This project has a [CircleCI](https://circleci.com/) implementation to compile and run unit tests as well as simple integration tests against a local `nginx` instance.
 
-Any patchests or features added should include relevant tests to increase the coverage of the library.
-Examples are also welcome if understanding how the feature works is difficult or provide some additional value the tests cannot.
+Currently tested distros:
+* ubuntu:rolling
+* fedora:latest
+
+Currently tested compilers:
+* g++
+* clang
+
+Contributing should ideally be a single commit if possible.  Any new feature should include relevant tests and examples 
+are welcome if understanding how the feature works is difficult or provides some additional value the tests otherwise cannot.
 
 CMake is setup to understand how to run the tests.  Building and then running `ctest` will
 execute the tests locally.  Note that the integration tests that make HTTP calls require a webserver

--- a/test/UserDataRequestTest.hpp
+++ b/test/UserDataRequestTest.hpp
@@ -23,16 +23,21 @@ static auto user_data_on_complete(lift::RequestHandle request, uint64_t user_dat
 
 TEST_CASE("User data")
 {
-    uint64_t request_id = 0;
-
     lift::EventLoop event_loop{};
+
+    // Technically can hard code in this instance for the lambda captures, but to make it a bit
+    // more like an example we'll include a unique "request_id" that gets captured as the user data.
+    uint64_t request_id = 1;
+
     auto& request_pool = event_loop.GetRequestPool();
     auto req1 = request_pool.Produce("http://localhost:80/", std::chrono::seconds{1});
-    req1->SetOnCompleteHandler([&](lift::RequestHandle r) { user_data_on_complete(std::move(r), ++request_id, 100.5); });
+    req1->SetOnCompleteHandler([request_id](lift::RequestHandle r) { user_data_on_complete(std::move(r), request_id, 100.5); });
     event_loop.StartRequest(std::move(req1));
 
+    request_id = 2;
+
     auto req2 = request_pool.Produce("http://localhost:80/", std::chrono::seconds{1});
-    req2->SetOnCompleteHandler([&](lift::RequestHandle r) { user_data_on_complete(std::move(r), ++request_id, 1234.567); });
+    req2->SetOnCompleteHandler([request_id](lift::RequestHandle r) { user_data_on_complete(std::move(r), request_id, 1234.567); });
     event_loop.StartRequest(std::move(req2));
 
     while (event_loop.GetActiveRequestCount() > 0) {


### PR DESCRIPTION
The CI tests don't run as fast as locally and showed a data race on the request_id lambda capture.