### PR TITLE
CMake public inc/link correctly for lifthttp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 2.8)
 project(lifthttp CXX)
 
 find_program(CLANG_TIDY_BIN NAMES "clang-tidy" DOC "clang-tidy binary location")
@@ -58,13 +58,13 @@ set(LIBLIFT_SOURCE_FILES
     inc/lift/ResolveHost.hpp src/ResolveHost.cpp
 )
 
-add_library(${PROJECT_NAME} STATIC ${LIBLIFT_SOURCE_FILES})
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+add_library(${PROJECT_NAME} STATIC SHARED ${LIBLIFT_SOURCE_FILES})
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
-target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${CURL_INCLUDE})
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${CURL_INCLUDE})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${LIFT_LIB_DEPS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${LIFT_LIB_DEPS})
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     target_compile_options(

--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ while(loop.GetActiveRequestCount() > 0) {
     pthreads/std::thread
     libcurl devel
     libuv devel
+    zlib devel
 
 ## Instructions
 
 ### Building
-    # This will produce a static library to link against your project.
+    # This will produce a shared and static library to link against your project.
     mkdir Release && cd Release
     cmake -DCMAKE_BUILD_TYPE=Release ..
     cmake --build .
@@ -104,16 +105,13 @@ assuming the lift code is in a `liblifthttp/` subdirectory of the parent project
 To link to the `<project_name>` then use the following:
     
     add_executable(<project_name> main.cpp)
-    target_link_libraries(<project_name> PRIVATE lifthttp ${LIFT_LIB_DEPS})
-    target_compile_features(<project_name> PRIVATE cxx_std_17)
-    target_include_directories(<project_name> SYSTEM PRIVATE ${CURL_INCLUDE})
+    target_link_libraries(<project_name> PRIVATE lifthttp)
 
 Include lift in the project's code by simply including `#include <lift/lift.hpp>` as needed.
 
-Note that by default liblifthttp will attempt to use system versions of `libcurl-dev` 
-and `libuv-dev`.  If your project, like some of mine do, require a custom built version 
-of `libcurl` then you can specify the following `cmake` variables to override where liblifthttp
-will link `libcurl` development libraries: (custom `libuv` not supported yet)
+Note that by default liblifthttp will attempt to use system versions of `libcurl-dev`, `libuv-dev`, `libcrypto-dev`, `libssl-dev`, and `libcares-dev`.  If your project, like some of mine do, require a custom built version 
+of `libcurl` or any of the other libraries that curl links to then you can specify the following `cmake` variables to override where liblifthttp
+will link `libcurl` development libraries.  These can be dynamic or static libraries.  Note that a custom `libuv-dev` link is not currently supported.
 
     ${CURL_INCLUDE} # The curl.h header location, default is empty.
     ${LIBSSL}       # The ssl library to link against, default is empty.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,29 +1,14 @@
 cmake_minimum_required(VERSION 2.8)
-project(liblifthttp_examples)
+project(liblifthttp_examples CXX)
 
 ### synch_simple ###
-set(LIBLIFTHTTP_SYNCH_SIMPLE_SOURCE_FILES
-    synch_simple.cpp
-)
-add_executable(lift_synch_simple ${LIBLIFTHTTP_SYNCH_SIMPLE_SOURCE_FILES})
-target_link_libraries(lift_synch_simple PRIVATE lifthttp ${LIFT_LIB_DEPS})
-target_compile_features(lift_synch_simple PRIVATE cxx_std_17)
-target_include_directories(lift_synch_simple SYSTEM PRIVATE ${CURL_INCLUDE})
+add_executable(lift_synch_simple synch_simple.cpp)
+target_link_libraries(lift_synch_simple PRIVATE lifthttp)
 
 ### async_simple ###
-set(LIBLIFTHTTP_ASYNC_SIMPLE_SOURCE_FILES
-    async_simple.cpp
-)
-add_executable(lift_async_simple ${LIBLIFTHTTP_ASYNC_SIMPLE_SOURCE_FILES})
-target_link_libraries(lift_async_simple PRIVATE lifthttp ${LIFT_LIB_DEPS})
-target_compile_features(lift_async_simple PRIVATE cxx_std_17)
-target_include_directories(lift_async_simple SYSTEM PRIVATE ${CURL_INCLUDE})
+add_executable(lift_async_simple async_simple.cpp)
+target_link_libraries(lift_async_simple PRIVATE lifthttp)
 
 ### benchmark ###
-set(LIBLIFTHTTP_BENCHMARK_SOURCE_FILES
-    benchmark.cpp
-)
-add_executable(lift_benchmark ${LIBLIFTHTTP_BENCHMARK_SOURCE_FILES})
-target_link_libraries(lift_benchmark PRIVATE lifthttp ${LIFT_LIB_DEPS})
-target_compile_features(lift_benchmark PRIVATE cxx_std_17)
-target_include_directories(lift_benchmark SYSTEM PRIVATE ${CURL_INCLUDE})
+add_executable(lift_benchmark benchmark.cpp)
+target_link_libraries(lift_benchmark PRIVATE lifthttp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,10 +11,6 @@ set(LIBLIFT_TEST_SOURCE_FILES
 )
 
 add_executable(${PROJECT_NAME} main.cpp ${LIBLIFT_TEST_SOURCE_FILES})
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-target_link_libraries(${PROJECT_NAME} PRIVATE
-    ${LIFT_CURL_LIBRARY_DEPENDENCIES}
-    ${LIFT_SYSTEM_LIBRARY_DEPENDENCIES}
-    lifthttp
-)
+target_link_libraries(${PROJECT_NAME} PRIVATE lifthttp)
+
 add_test(NAME LiftHttpTest COMMAND ${PROJECT_NAME})


### PR DESCRIPTION
Previously the user had to manually target include directories a macro for the libcurl include as well as manually target link libraries for the curl dependencies.  The cmake file will now publicly export these from the `lifthttp` target for any project that links to this target.