### PR TITLE
Timesup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,17 @@ static lift::GlobalScopeInitializer g_lifthttp_gsi{};
 
 ### Simple Synchronous
 ```C++
-// Requests are always produced from a pool and return to the pool upon completion.
+// Synchronous requests can be created on the stack.
 lift::Request request{"http://www.example.com"};
-// This call is the blocking synchronous HTTP call.
+// This is the blocking synchronous HTTP call.
 auto response = request.Perform();
-std::cout << response.Data() << "\n";
+std::cout << "LiftStatus: " << lift::to_string(response.LiftStatus()) << "\n";
+std::cout << "HTTP Status Code: " << lift::to_string(response.StatusCode()) << "\n";
+for(const auto& header : response.Headers())
+{
+    std::cout << header.Name() << ": " << header.Value() << "\n";
+}
+std::cout << response.Data(); 
 ```
 
 ### Simple Asynchronous

--- a/inc/lift/LiftStatus.hpp
+++ b/inc/lift/LiftStatus.hpp
@@ -28,6 +28,14 @@ enum class LiftStatus {
     /// The request has an SSL connection error.
     CONNECT_SSL_ERROR,
 
+    /// The request had its timesup expire.  Timesup is a two tier timeout
+    /// where the client is notified when timesup expires for the request
+    /// but Lift will continue trying to establish the request until timeout.
+    /// This is important for TLS or establishing connections when the timeout
+    /// of the request _should_ be very short and otherwise would make new
+    /// connections with a single timeout value very difficult and cause lots
+    /// of connection churn.
+    TIMESUP,
     /// The request timed out.
     TIMEOUT,
     /// The request has an empty response (socket severed).

--- a/inc/lift/Response.hpp
+++ b/inc/lift/Response.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * @return The number of redirects made during this request.
      */
-    [[nodiscard]] auto NumRedirects() const -> uint64_t { return m_num_redircts; }
+    [[nodiscard]] auto NumRedirects() const -> uint64_t { return m_num_redirects; }
 
 private:
     /// The status of this HTTP request.
@@ -84,7 +84,7 @@ private:
     /// The number of times attempted to connect to the remote server.
     uint64_t m_num_connects{ 0 };
     /// The number of redirects traversed while processing the request.
-    uint64_t m_num_redircts{ 0 };
+    uint64_t m_num_redirects{ 0 };
 
     /// libcurl will call this function when a header is received for the HTTP request.
     friend auto curl_write_header(
@@ -111,6 +111,10 @@ private:
     /// libuv will call this function when the StartRequest() function is called.
     friend auto on_uv_requests_accept_async(
         uv_async_t* handle) -> void;
+
+    /// For Timesup.
+    friend auto on_uv_timesup_callback(
+        uv_timer_t* handle) -> void;
 };
 
 } // namespace lift

--- a/src/LiftStatus.cpp
+++ b/src/LiftStatus.cpp
@@ -10,6 +10,7 @@ static const std::string LIFT_STATUS_SUCCESS = "SUCCESS"s;
 static const std::string LIFT_STATUS_CONNECT_ERROR = "CONNECT_ERROR"s;
 static const std::string LIFT_STATUS_CONNECT_DNS_ERROR = "CONNECT_DNS_ERROR"s;
 static const std::string LIFT_STATUS_CONNECT_SSL_ERROR = "CONNECT_SSL_ERROR"s;
+static const std::string LIFT_STATUS_TIMESUP = "TIMESUP"s;
 static const std::string LIFT_STATUS_TIMEOUT = "TIMEOUT"s;
 static const std::string LIFT_STATUS_RESPONSE_EMPTY = "RESPONSE_EMPTY"s;
 static const std::string LIFT_STATUS_ERROR_FAILED_TO_START = "ERROR_FAILED_TO_START"s;
@@ -32,6 +33,8 @@ auto to_string(
         return LIFT_STATUS_CONNECT_DNS_ERROR;
     case LiftStatus::CONNECT_SSL_ERROR:
         return LIFT_STATUS_CONNECT_SSL_ERROR;
+    case LiftStatus::TIMESUP:
+        return LIFT_STATUS_TIMESUP;
     case LiftStatus::TIMEOUT:
         return LIFT_STATUS_TIMEOUT;
     case LiftStatus::RESPONSE_EMPTY:

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -38,58 +38,19 @@ auto Request::TransferProgressHandler(
     }
 }
 
-auto Request::Timeout() const -> const std::optional<std::chrono::milliseconds>&
+auto Request::Timesup(
+    std::optional<std::chrono::milliseconds> timesup) -> void
 {
-    return m_timeout;
-}
 
-auto Request::Timeout(
-    std::optional<std::chrono::milliseconds> timeout) -> void
-{
-    m_timeout = std::move(timeout);
-}
+    if (timesup.has_value() && timesup.value() >= m_timeout.value_or(std::chrono::milliseconds{ 0 })) {
+        throw std::logic_error(
+            "Times up "
+            + std::to_string(timesup.value().count())
+            + " cannot be <= than timeout "
+            + std::to_string(m_timeout.value_or(std::chrono::milliseconds{ 0 }).count()));
+    }
 
-auto Request::Url() const -> const std::string&
-{
-    return m_url;
-}
-
-auto Request::Url(
-    std::string url) -> void
-{
-    m_url = std::move(url);
-}
-
-auto Request::Method() const -> http::Method
-{
-    return m_method;
-}
-
-auto Request::Method(
-    http::Method method) -> void
-{
-    m_method = method;
-}
-
-auto Request::Version() const -> http::Version
-{
-    return m_version;
-}
-
-auto Request::Version(
-    http::Version version) -> void
-{
-    m_version = version;
-}
-
-auto Request::FollowRedirects() const -> bool
-{
-    return m_follow_redirects;
-}
-
-auto Request::MaxRedirects() const -> int64_t
-{
-    return m_max_redirects;
+    m_timesup = std::move(timesup);
 }
 
 auto Request::FollowRedirects(
@@ -107,55 +68,6 @@ auto Request::FollowRedirects(
     } else {
         m_follow_redirects = false;
     }
-}
-
-auto Request::VerifySslPeer() const -> bool
-{
-    return m_verify_ssl_peer;
-}
-
-auto Request::VerifySslPeer(
-    bool verify_ssl_peer) -> void
-{
-    m_verify_ssl_peer = verify_ssl_peer;
-}
-
-auto Request::VerifySslHost() const -> bool
-{
-    return m_verify_ssl_host;
-}
-
-auto Request::VerifySslHost(
-    bool verify_ssl_host) -> void
-{
-    m_verify_ssl_host = verify_ssl_host;
-}
-
-auto Request::AcceptEncodings() const -> const std::optional<std::vector<std::string>>&
-{
-    return m_accept_encodings;
-}
-auto Request::AcceptEncoding(
-    std::optional<std::vector<std::string>> encodings) -> void
-{
-    m_accept_encodings = std::move(encodings);
-}
-
-auto Request::ResolveHosts() const -> const std::vector<lift::ResolveHost>&
-{
-    return m_resolve_hosts;
-}
-
-auto Request::ResolveHost(
-    lift::ResolveHost resolve_host) -> void
-{
-    m_resolve_hosts.emplace_back(std::move(resolve_host));
-}
-
-auto Request::RemoveHeader(
-    std::string_view name) -> void
-{
-    Header(name, std::string_view{});
 }
 
 auto Request::Header(
@@ -185,17 +97,7 @@ auto Request::Header(
     m_request_headers_idx.emplace_back(full_header);
 }
 
-auto Request::Headers() const -> const std::vector<HeaderView>&
-{
-    return m_request_headers_idx;
-}
-
-auto Request::RequestData() const -> const std::string&
-{
-    return m_request_data;
-}
-
-auto Request::RequestData(
+auto Request::Data(
     std::string data) -> void
 {
     if (m_mime_fields_set) {
@@ -205,11 +107,6 @@ auto Request::RequestData(
     m_request_data_set = true;
     m_request_data = std::move(data);
     m_method = http::Method::POST;
-}
-
-auto Request::MimeFields() const -> const std::vector<lift::MimeField>&
-{
-    return m_mime_fields;
 }
 
 auto Request::MimeField(

--- a/test/AsyncRequestTest.hpp
+++ b/test/AsyncRequestTest.hpp
@@ -71,7 +71,7 @@ TEST_CASE("Async POST request")
             REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_405_METHOD_NOT_ALLOWED);
         });
-    request->RequestData(data);
+    request->Data(data);
     request->Method(lift::http::Method::POST);
     request->FollowRedirects(true);
     request->Version(lift::http::Version::V1_1);
@@ -86,7 +86,7 @@ TEST_CASE("Async POST request")
             REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_405_METHOD_NOT_ALLOWED);
         });
-    request->RequestData(data);
+    request->Data(data);
     request->Method(lift::http::Method::POST);
     request->FollowRedirects(true);
     request->Version(lift::http::Version::V1_1);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBLIFT_TEST_SOURCE_FILES
     EscapeTest.hpp
     QueryBuilderTest.hpp
     SyncRequestTest.hpp
+    TimesupTest.hpp
     TransferProgressRequest.hpp
     UserDataRequestTest.hpp
 )

--- a/test/TimesupTest.hpp
+++ b/test/TimesupTest.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "catch.hpp"
+
+#include <lift/Lift.hpp>
+
+#include <chrono>
+#include <vector>
+
+TEST_CASE("Timesup single request")
+{
+    lift::EventLoop ev{};
+
+    auto r = lift::Request::make(
+        "http://www.reddit.com", // should be slow enough /shrug
+        std::chrono::milliseconds{ 25 },
+        std::chrono::seconds{ 1 },
+        [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 25 });
+            REQUIRE(response.NumConnects() == 0);
+            REQUIRE(response.NumRedirects() == 0);
+        });
+
+    ev.StartRequest(std::move(r));
+
+    while (ev.ActiveRequestCount() > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+    }
+}
+
+TEST_CASE("Timesup two requests")
+{
+    lift::EventLoop ev{};
+
+    std::vector<lift::RequestPtr> requests{};
+
+    requests.push_back(lift::Request::make(
+        "http://www.reddit.com", // should be slow enough /shrug
+        std::chrono::milliseconds{ 25 },
+        std::chrono::seconds{ 1 },
+        [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 25 });
+        }));
+
+    requests.push_back(lift::Request::make(
+        "http://www.reddit.com", // should be slow enough /shrug
+        std::chrono::milliseconds{ 50 },
+        std::chrono::seconds{ 1 },
+        [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 50 });
+        }));
+
+    ev.StartRequests(std::move(requests));
+
+    while (ev.ActiveRequestCount() > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+    }
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -9,5 +9,6 @@ static lift::GlobalScopeInitializer g_lift_gsi{};
 #include "EscapeTest.hpp"
 #include "QueryBuilderTest.hpp"
 #include "SyncRequestTest.hpp"
+#include "TimesupTest.hpp"
 #include "TransferProgressRequest.hpp"
 #include "UserDataRequestTest.hpp"


### PR DESCRIPTION
Add Async Timesup feature
    
    Asynchronous requests that have
    very small timeout values can have
    trouble establishing connections
    especially if they use TLS, etc.
    
    To attempt to solve this problem a
    timesup feature is introduced that
    is a two tier timeout system.  The
    asynchronous request is given a shorter
    timesup value that the application
    is willing to wait for this period
    of time for a response and then a
    normal timeout value for establishing
    connections.  The application is
    notified as usual of a 'timesup'
    when the shorter timer expires
    but won't be notified of the longer
    timeout value if that also expires.
    If the connection is established
    in the time between timesup and timeout
    then the response is thrown away
    but the connection is maintained
    so the next request might succeed
    since it no longer needs to connect.