### PR TITLE
Rename timesup to connection time feature

### DIFF
--- a/examples/async_simple.cpp
+++ b/examples/async_simple.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
     (void)argv;
 
     // Initialize must be called first before using the LiftHttp library.
-    lift::GlobalScopeInitializer lift_init{};
+    lift::GlobalScopeInitializer lift_init {};
 
     std::vector<std::string> urls = {
         "http://www.example.com",
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
         "http://www.reddit.com"
     };
 
-    lift::EventLoop event_loop{};
+    lift::EventLoop event_loop {};
 
     /**
      * Create asynchronous requests for each url and inject them into

--- a/examples/benchmark.cpp
+++ b/examples/benchmark.cpp
@@ -41,15 +41,15 @@ int main(int argc, char* argv[])
     using namespace std::chrono_literals;
 
     std::string url(argv[1]);
-    auto duration = std::chrono::seconds{ std::stoul(argv[2]) };
+    auto duration = std::chrono::seconds { std::stoul(argv[2]) };
     uint64_t connections = std::stoul(argv[3]);
     uint64_t threads = std::stoul(argv[4]);
 
     // Initialize must be called first before using the LiftHttp library.
-    lift::GlobalScopeInitializer lift_init{};
+    lift::GlobalScopeInitializer lift_init {};
 
-    std::atomic<uint64_t> success{ 0 };
-    std::atomic<uint64_t> error{ 0 };
+    std::atomic<uint64_t> success { 0 };
+    std::atomic<uint64_t> error { 0 };
 
     {
         std::vector<std::unique_ptr<lift::EventLoop>> loops;

--- a/examples/synch_simple.cpp
+++ b/examples/synch_simple.cpp
@@ -8,17 +8,17 @@ int main(int argc, char* argv[])
     (void)argv;
 
     // Initialize must be called first before using the LiftHttp library.
-    lift::GlobalScopeInitializer lift_init{};
+    lift::GlobalScopeInitializer lift_init {};
 
     {
-        lift::Request request{ "http://www.example.com" };
+        lift::Request request { "http://www.example.com" };
         std::cout << "Requesting http://www.example.com" << std::endl;
         const auto& response = request.Perform();
         std::cout << response.Data() << std::endl;
     }
 
     {
-        lift::Request request{ "http://www.google.com" };
+        lift::Request request { "http://www.google.com" };
         std::cout << "Requesting http://www.google.com" << std::endl;
         const auto& response = request.Perform();
         std::cout << response.Data() << std::endl;

--- a/inc/lift/Executor.hpp
+++ b/inc/lift/Executor.hpp
@@ -36,28 +36,28 @@ public:
 
 private:
     /// The curl handle to execute against.
-    CURL* m_curl_handle{ nullptr };
+    CURL* m_curl_handle { nullptr };
     /// The mime handle if present.
-    curl_mime* m_mime_handle{ nullptr };
+    curl_mime* m_mime_handle { nullptr };
     /// The HTTP curl request headers.
-    std::vector<curl_slist> m_curl_request_headers{};
+    std::vector<curl_slist> m_curl_request_headers {};
     /// The HTTP curl resolve hosts.
-    curl_slist* m_curl_resolve_hosts{ nullptr };
+    curl_slist* m_curl_resolve_hosts { nullptr };
 
     /// If sync request the pointer to the request.
-    Request* m_request_sync{ nullptr };
+    Request* m_request_sync { nullptr };
 
     /// If async request the event loop executing this request.
-    EventLoop* m_event_loop{ nullptr };
+    EventLoop* m_event_loop { nullptr };
     /// If async request the pointer to the request.
-    RequestPtr m_request_async{ nullptr };
-    /// If the async request has a timeup set then this is the position to delete when completed.
-    std::optional<std::multimap<uint64_t, Executor*>::iterator> m_timesup_iterator;
+    RequestPtr m_request_async { nullptr };
+    /// If the async request has a timeout set then this is the position to delete when completed.
+    std::optional<std::multimap<uint64_t, Executor*>::iterator> m_timeout_iterator;
     // Has the on complete callback been called already?
-    bool m_on_complete_callback_called{ false };
+    bool m_on_complete_callback_called { false };
 
     /// Used internally to point at one of the sync or async requests.
-    Request* m_request{ nullptr };
+    Request* m_request { nullptr };
 
     /// The HTTP response data.
     Response m_response;
@@ -66,7 +66,7 @@ private:
         RequestPtr request_ptr,
         EventLoop* event_loop) -> std::unique_ptr<Executor>
     {
-        return std::unique_ptr<Executor>(new Executor{ std::move(request_ptr), event_loop });
+        return std::unique_ptr<Executor>(new Executor { std::move(request_ptr), event_loop });
     }
 
     /**

--- a/inc/lift/HeaderView.hpp
+++ b/inc/lift/HeaderView.hpp
@@ -39,7 +39,7 @@ private:
     /// The header's name.
     std::string_view m_name;
     /// The header's value if it has one.
-    std::string_view m_value{};
+    std::string_view m_value {};
 };
 
 } // lift

--- a/inc/lift/LiftStatus.hpp
+++ b/inc/lift/LiftStatus.hpp
@@ -28,14 +28,6 @@ enum class LiftStatus {
     /// The request has an SSL connection error.
     CONNECT_SSL_ERROR,
 
-    /// The request had its timesup expire.  Timesup is a two tier timeout
-    /// where the client is notified when timesup expires for the request
-    /// but Lift will continue trying to establish the request until timeout.
-    /// This is important for TLS or establishing connections when the timeout
-    /// of the request _should_ be very short and otherwise would make new
-    /// connections with a single timeout value very difficult and cause lots
-    /// of connection churn.
-    TIMESUP,
     /// The request timed out.
     TIMEOUT,
     /// The request has an empty response (socket severed).

--- a/inc/lift/MimeField.hpp
+++ b/inc/lift/MimeField.hpp
@@ -23,8 +23,8 @@ public:
     auto Value() const -> const std::variant<std::string, std::filesystem::path>& { return m_field_value; }
 
 private:
-    std::string m_field_name{};
-    std::variant<std::string, std::filesystem::path> m_field_value{};
+    std::string m_field_name {};
+    std::variant<std::string, std::filesystem::path> m_field_value {};
 };
 
 } // namespace lift

--- a/inc/lift/QueryBuilder.hpp
+++ b/inc/lift/QueryBuilder.hpp
@@ -109,7 +109,7 @@ private:
     /// The url hostname.
     std::string_view m_hostname;
     /// The url port.
-    uint16_t m_port{ 0 };
+    uint16_t m_port { 0 };
     /// The path parts in order.
     std::vector<std::string_view> m_path_parts;
     /// The query parameters (unescaped), they are escaped in Build().

--- a/inc/lift/Response.hpp
+++ b/inc/lift/Response.hpp
@@ -70,21 +70,21 @@ public:
 
 private:
     /// The status of this HTTP request.
-    lift::LiftStatus m_lift_status{ lift::LiftStatus::BUILDING };
+    lift::LiftStatus m_lift_status { lift::LiftStatus::BUILDING };
     /// The response headers.
-    std::string m_headers{};
+    std::string m_headers {};
     /// Views into each header.
-    std::vector<HeaderView> m_headers_idx{};
+    std::vector<HeaderView> m_headers_idx {};
     /// The response data if any.
-    std::string m_data{};
+    std::string m_data {};
     /// The HTTP response status code.
-    lift::http::StatusCode m_status_code{ lift::http::StatusCode::HTTP_UNKNOWN };
+    lift::http::StatusCode m_status_code { lift::http::StatusCode::HTTP_UNKNOWN };
     /// The total time in milliseconds to execute the request.
-    std::chrono::milliseconds m_total_time{ 0 };
+    std::chrono::milliseconds m_total_time { 0 };
     /// The number of times attempted to connect to the remote server.
-    uint64_t m_num_connects{ 0 };
+    uint64_t m_num_connects { 0 };
     /// The number of redirects traversed while processing the request.
-    uint64_t m_num_redirects{ 0 };
+    uint64_t m_num_redirects { 0 };
 
     /// libcurl will call this function when a header is received for the HTTP request.
     friend auto curl_write_header(

--- a/src/Escape.cpp
+++ b/src/Escape.cpp
@@ -14,12 +14,12 @@ auto escape(
         static_cast<int32_t>(data.length()));
 
     if (escaped_data != nullptr) {
-        std::string value{ escaped_data };
+        std::string value { escaped_data };
         curl_free(escaped_data);
         return value;
     }
 
-    return std::string{};
+    return std::string {};
 }
 
 auto unescape_recurse(
@@ -41,12 +41,12 @@ auto unescape(
         static_cast<int32_t>(escaped_data.length()));
 
     if (decoded_data != nullptr) {
-        std::string value{ decoded_data };
+        std::string value { decoded_data };
         curl_free(decoded_data);
         return value;
     }
 
-    return std::string{};
+    return std::string {};
 }
 
 } // lift

--- a/src/Lift.cpp
+++ b/src/Lift.cpp
@@ -6,7 +6,7 @@ namespace lift {
 
 auto startup() -> void
 {
-    static std::atomic<uint64_t> initialized{ 0 };
+    static std::atomic<uint64_t> initialized { 0 };
 
     if (initialized.fetch_add(1) == 0) {
         curl_global_init(CURL_GLOBAL_ALL);
@@ -15,7 +15,7 @@ auto startup() -> void
 
 auto shutdown() -> void
 {
-    static std::atomic<uint64_t> cleaned{ 0 };
+    static std::atomic<uint64_t> cleaned { 0 };
 
     if (cleaned.fetch_add(1) == 0) {
         curl_global_cleanup();

--- a/src/LiftStatus.cpp
+++ b/src/LiftStatus.cpp
@@ -10,7 +10,6 @@ static const std::string LIFT_STATUS_SUCCESS = "SUCCESS"s;
 static const std::string LIFT_STATUS_CONNECT_ERROR = "CONNECT_ERROR"s;
 static const std::string LIFT_STATUS_CONNECT_DNS_ERROR = "CONNECT_DNS_ERROR"s;
 static const std::string LIFT_STATUS_CONNECT_SSL_ERROR = "CONNECT_SSL_ERROR"s;
-static const std::string LIFT_STATUS_TIMESUP = "TIMESUP"s;
 static const std::string LIFT_STATUS_TIMEOUT = "TIMEOUT"s;
 static const std::string LIFT_STATUS_RESPONSE_EMPTY = "RESPONSE_EMPTY"s;
 static const std::string LIFT_STATUS_ERROR_FAILED_TO_START = "ERROR_FAILED_TO_START"s;
@@ -33,8 +32,6 @@ auto to_string(
         return LIFT_STATUS_CONNECT_DNS_ERROR;
     case LiftStatus::CONNECT_SSL_ERROR:
         return LIFT_STATUS_CONNECT_SSL_ERROR;
-    case LiftStatus::TIMESUP:
-        return LIFT_STATUS_TIMESUP;
     case LiftStatus::TIMEOUT:
         return LIFT_STATUS_TIMEOUT;
     case LiftStatus::RESPONSE_EMPTY:

--- a/src/QueryBuilder.cpp
+++ b/src/QueryBuilder.cpp
@@ -90,12 +90,12 @@ auto QueryBuilder::reset() -> void
 {
     m_query.clear();
     m_query.str("");
-    m_scheme = std::string_view{};
-    m_hostname = std::string_view{};
+    m_scheme = std::string_view {};
+    m_hostname = std::string_view {};
     m_port = 0;
     m_path_parts.clear();
     m_query_parameters.clear();
-    m_fragment = std::string_view{};
+    m_fragment = std::string_view {};
 }
 
 } // lift

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -18,7 +18,7 @@ Request::Request(
 
 auto Request::Perform() -> Response
 {
-    Executor executor{ this };
+    Executor executor { this };
     return executor.perform();
 }
 
@@ -36,21 +36,6 @@ auto Request::TransferProgressHandler(
     } else {
         m_on_transfer_progress_handler = nullptr;
     }
-}
-
-auto Request::Timesup(
-    std::optional<std::chrono::milliseconds> timesup) -> void
-{
-
-    if (timesup.has_value() && timesup.value() >= m_timeout.value_or(std::chrono::milliseconds{ 0 })) {
-        throw std::logic_error(
-            "Times up "
-            + std::to_string(timesup.value().count())
-            + " cannot be <= than timeout "
-            + std::to_string(m_timeout.value_or(std::chrono::milliseconds{ 0 }).count()));
-    }
-
-    m_timesup = std::move(timesup);
 }
 
 auto Request::FollowRedirects(
@@ -93,7 +78,7 @@ auto Request::Header(
     }
     m_request_headers += '\0'; // curl expects null byte, do not use string.append, it ignores null terminators!
 
-    std::string_view full_header{ start, header_len - 1 }; // subtract off the null byte
+    std::string_view full_header { start, header_len - 1 }; // subtract off the null byte
     m_request_headers_idx.emplace_back(full_header);
 }
 

--- a/test/AsyncRequestTest.hpp
+++ b/test/AsyncRequestTest.hpp
@@ -11,12 +11,12 @@ TEST_CASE("Async 100 requests")
 {
     constexpr std::size_t COUNT = 100;
 
-    lift::EventLoop ev{};
+    lift::EventLoop ev {};
 
     for (std::size_t i = 0; i < COUNT; ++i) {
         auto r = std::make_unique<lift::Request>(
             "http://localhost:80/",
-            std::chrono::seconds{ 1 },
+            std::chrono::seconds { 1 },
             [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
                 REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
                 REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_200_OK);
@@ -26,7 +26,7 @@ TEST_CASE("Async 100 requests")
     }
 
     while (ev.ActiveRequestCount() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+        std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
     }
 }
 
@@ -34,15 +34,15 @@ TEST_CASE("Async batch 100 requests")
 {
     constexpr std::size_t COUNT = 100;
 
-    lift::EventLoop ev{};
+    lift::EventLoop ev {};
 
-    std::vector<std::unique_ptr<lift::Request>> handles{};
+    std::vector<std::unique_ptr<lift::Request>> handles {};
     handles.reserve(COUNT);
 
     for (std::size_t i = 0; i < COUNT; ++i) {
         auto r = std::make_unique<lift::Request>(
             "http://localhost:80/",
-            std::chrono::seconds{ 1 },
+            std::chrono::seconds { 1 },
             [](std::unique_ptr<lift::Request>, lift::Response response) -> void {
                 REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
                 REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_200_OK);
@@ -54,19 +54,19 @@ TEST_CASE("Async batch 100 requests")
     ev.StartRequests(std::move(handles));
 
     while (ev.ActiveRequestCount() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+        std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
     }
 }
 
 TEST_CASE("Async POST request")
 {
-    lift::EventLoop ev{};
+    lift::EventLoop ev {};
 
     std::string data = "DATA DATA DATA!";
 
     auto request = std::make_unique<lift::Request>(
         "http://localhost:80/",
-        std::chrono::seconds{ 60 },
+        std::chrono::seconds { 60 },
         [&](std::unique_ptr<lift::Request>, lift::Response response) {
             REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_405_METHOD_NOT_ALLOWED);
@@ -81,7 +81,7 @@ TEST_CASE("Async POST request")
 
     request = std::make_unique<lift::Request>(
         "http://localhost:80/",
-        std::chrono::seconds{ 60 },
+        std::chrono::seconds { 60 },
         [&](std::unique_ptr<lift::Request>, lift::Response response) {
             REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_405_METHOD_NOT_ALLOWED);

--- a/test/QueryBuilderTest.hpp
+++ b/test/QueryBuilderTest.hpp
@@ -6,7 +6,7 @@
 
 TEST_CASE("Query Builder simple")
 {
-    lift::QueryBuilder query_builder{};
+    lift::QueryBuilder query_builder {};
     query_builder
         .Scheme("https")
         .Hostname("www.example.com")

--- a/test/TimesupTest.hpp
+++ b/test/TimesupTest.hpp
@@ -9,16 +9,15 @@
 
 TEST_CASE("Timesup single request")
 {
-    lift::EventLoop ev{};
+    lift::EventLoop ev { std::nullopt, std::nullopt, { std::chrono::seconds { 1 } } };
 
     auto r = lift::Request::make(
         "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{ 25 },
-        std::chrono::seconds{ 1 },
+        std::chrono::milliseconds { 25 },
         [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
-            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMEOUT);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
-            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 25 });
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds { 25 });
             REQUIRE(response.NumConnects() == 0);
             REQUIRE(response.NumRedirects() == 0);
         });
@@ -26,39 +25,37 @@ TEST_CASE("Timesup single request")
     ev.StartRequest(std::move(r));
 
     while (ev.ActiveRequestCount() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+        std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
     }
 }
 
 TEST_CASE("Timesup two requests")
 {
-    lift::EventLoop ev{};
+    lift::EventLoop ev { std::nullopt, std::nullopt, { std::chrono::seconds { 1 } } };
 
-    std::vector<lift::RequestPtr> requests{};
+    std::vector<lift::RequestPtr> requests {};
 
     requests.push_back(lift::Request::make(
         "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{ 25 },
-        std::chrono::seconds{ 1 },
+        std::chrono::milliseconds { 25 },
         [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
-            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMEOUT);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
-            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 25 });
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds { 25 });
         }));
 
     requests.push_back(lift::Request::make(
         "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{ 50 },
-        std::chrono::seconds{ 1 },
+        std::chrono::milliseconds { 50 },
         [](std::unique_ptr<lift::Request> rh, lift::Response response) -> void {
-            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMESUP);
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::TIMEOUT);
             REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_UNKNOWN);
-            REQUIRE(response.TotalTime() == std::chrono::milliseconds{ 50 });
+            REQUIRE(response.TotalTime() == std::chrono::milliseconds { 50 });
         }));
 
     ev.StartRequests(std::move(requests));
 
     while (ev.ActiveRequestCount() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+        std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
     }
 }

--- a/test/UserDataRequestTest.hpp
+++ b/test/UserDataRequestTest.hpp
@@ -22,13 +22,13 @@ static auto user_data_on_complete(
 
 TEST_CASE("User data")
 {
-    lift::EventLoop event_loop{};
+    lift::EventLoop event_loop {};
 
     // Technically can hard code in this instance for the lambda captures, but to make it a bit
     // more like an example we'll include a unique "request_id" that gets captured as the user data.
     uint64_t request_id = 1;
 
-    auto req1 = std::make_unique<lift::Request>("http://localhost:80/", std::chrono::seconds{ 1 });
+    auto req1 = std::make_unique<lift::Request>("http://localhost:80/", std::chrono::seconds { 1 });
     req1->OnCompleteHandler(
         [request_id](lift::RequestPtr request, lift::Response response) {
             user_data_on_complete(std::move(request), std::move(response), request_id, 100.5);
@@ -37,7 +37,7 @@ TEST_CASE("User data")
 
     request_id = 2;
 
-    auto req2 = std::make_unique<lift::Request>("http://localhost:80/", std::chrono::seconds{ 1 });
+    auto req2 = std::make_unique<lift::Request>("http://localhost:80/", std::chrono::seconds { 1 });
     req2->OnCompleteHandler(
         [request_id](lift::RequestPtr request, lift::Response response) {
             user_data_on_complete(std::move(request), std::move(response), request_id, 1234.567);
@@ -45,6 +45,6 @@ TEST_CASE("User data")
     event_loop.StartRequest(std::move(req2));
 
     while (event_loop.ActiveRequestCount() > 0) {
-        std::this_thread::sleep_for(std::chrono::milliseconds{ 10 });
+        std::this_thread::sleep_for(std::chrono::milliseconds { 10 });
     }
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -3,7 +3,7 @@
 
 #include <lift/Lift.hpp>
 
-static lift::GlobalScopeInitializer g_lift_gsi{};
+static lift::GlobalScopeInitializer g_lift_gsi {};
 
 #include "AsyncRequestTest.hpp"
 #include "EscapeTest.hpp"


### PR DESCRIPTION
This now only exposes a timeout to the client
but allows for the client to add a connection time
value to each event loop.  This is a secondary
timeout value that the event loop will automatically
add to requests that have timeouts shorter than
the connection time value making the feature easier to use.