### PR TITLE
Implement #82 Add curl share options to event loop

### DIFF
--- a/test/EventLoopTest.hpp
+++ b/test/EventLoopTest.hpp
@@ -58,3 +58,51 @@ TEST_CASE("EventLoop Start event loop, then stop and add multiple requests.")
     ev.Stop();
     REQUIRE_FALSE(ev.StartRequests(std::move(requests2)));
 }
+
+TEST_CASE("EventLoop Share")
+{
+    auto lift_share_ptr = std::make_shared<lift::Share>(lift::ShareOptions::ALL);
+
+    lift::EventLoop ev1 {
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::vector<lift::ResolveHost> {},
+        lift_share_ptr
+    };
+
+    lift::EventLoop ev2 {
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        std::vector<lift::ResolveHost> {},
+        lift_share_ptr
+    };
+
+    auto request1 = lift::Request::make(
+        "http://" + NGINX_HOSTNAME + ":80/",
+        std::chrono::seconds { 60 },
+        [&](std::unique_ptr<lift::Request>, lift::Response response) {
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
+            REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_200_OK);
+        });
+
+    auto request2 = lift::Request::make(
+        "http://" + NGINX_HOSTNAME + ":80/",
+        std::chrono::seconds { 60 },
+        [&](std::unique_ptr<lift::Request>, lift::Response response) {
+            REQUIRE(response.LiftStatus() == lift::LiftStatus::SUCCESS);
+            REQUIRE(response.StatusCode() == lift::http::StatusCode::HTTP_200_OK);
+        });
+
+    ev1.StartRequest(std::move(request1));
+
+    while (ev1.ActiveRequestCount() > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    ev2.StartRequest(std::move(request2));
+
+    ev1.Stop();
+    ev2.Stop();
+}


### PR DESCRIPTION
This will allow multiple different event loops to share
connection information for DNS/SSL/Data pipelining at
the cost of locking.