### PR TITLE
Issue #77 Event loop Executor pool

### DIFF
--- a/inc/lift/EventLoop.hpp
+++ b/inc/lift/EventLoop.hpp
@@ -47,7 +47,7 @@ public:
 private:
     CURLSH* m_curl_share_ptr { curl_share_init() };
 
-    std::array<std::mutex, static_cast<uint64_t>(CURL_LOCK_DATA_LAST)> m_curl_locks{};
+    std::array<std::mutex, static_cast<uint64_t>(CURL_LOCK_DATA_LAST)> m_curl_locks {};
 
     friend auto curl_share_lock(
         CURL* curl_ptr,
@@ -209,10 +209,10 @@ private:
     /// List of CurlContext objects to re-use for requests, cannot be initialized here due to CurlContext being private.
     std::deque<CurlContextPtr> m_curl_context_ready;
 
-    /// Lock for accessing curl handles.
-    std::mutex m_curl_handles_lock {};
-    /// List of CURL* handles to use for requests.
-    std::deque<CURL*> m_curl_handles {};
+    /// Lock for accessing executors.
+    std::mutex m_executors_lock {};
+    /// Pool of Executors for running requests.
+    std::deque<std::unique_ptr<Executor>> m_executors {};
 
     /// The set of resolve hosts to apply to all requests in this event loop.
     std::vector<lift::ResolveHost> m_resolve_hosts {};
@@ -293,8 +293,9 @@ private:
      */
     auto updateTimeouts() -> void;
 
-    auto acquireCurlHandle() -> CURL*;
-    auto returnCurlHandle(CURL* curl_handle) -> void;
+    auto acquireExecutor() -> std::unique_ptr<Executor>;
+    auto returnExecutor(
+        std::unique_ptr<Executor> executor_ptr) -> void;
 
     /**
      * This function is called by libcurl to start a timeout with duration timeout_ms.
@@ -400,7 +401,8 @@ auto EventLoop::StartRequests(
     // We'll prepare now since it won't block the event loop thread.
     // Since this might not be cheap do it outside the lock
     for (auto& request_ptr : requests) {
-        auto executor_ptr = Executor::make(std::move(request_ptr), this);
+        auto executor_ptr = acquireExecutor();
+        executor_ptr->startAsync(std::move(request_ptr));
         executor_ptr->prepare();
         executors.emplace_back(std::move(executor_ptr));
     }

--- a/inc/lift/Executor.hpp
+++ b/inc/lift/Executor.hpp
@@ -40,7 +40,7 @@ public:
 
 private:
     /// The curl handle to execute against.
-    CURL* m_curl_handle { nullptr };
+    CURL* m_curl_handle { curl_easy_init() };
     /// The mime handle if present.
     curl_mime* m_mime_handle { nullptr };
     /// The HTTP curl request headers.
@@ -66,11 +66,10 @@ private:
     /// The HTTP response data.
     Response m_response;
 
-    static auto make(
-        RequestPtr request_ptr,
+    static auto make_unique(
         EventLoop* event_loop) -> std::unique_ptr<Executor>
     {
-        return std::unique_ptr<Executor>(new Executor { std::move(request_ptr), event_loop });
+        return std::unique_ptr<Executor>(new Executor { event_loop });
     }
 
     /**
@@ -81,14 +80,14 @@ private:
         Request* request);
 
     /**
-     * This constructor is used for executing an asynchronous request.
-     * @param request_ptr Pass ownership of the request being executed
-     *                    into this executor.
+     * This constructor is used for executing an asynchronous requests.
      * @param event_loop The event loop that will execute this request.
      */
     Executor(
-        RequestPtr request_ptr,
         EventLoop* event_loop);
+
+    auto startAsync(
+        RequestPtr request_ptr) -> void;
 
     /**
      * Synchronously performs the request and returns the Response.
@@ -114,6 +113,8 @@ private:
      */
     auto setTimesupResponse(
         std::chrono::milliseconds total_time) -> void;
+
+    auto reset() -> void;
 
     /**
      * Converts a CURLcode into a LiftStatus.

--- a/src/EventLoop.cpp
+++ b/src/EventLoop.cpp
@@ -168,9 +168,9 @@ EventLoop::EventLoop(
     , m_share_ptr(std::move(share_ptr))
 {
     {
-        std::lock_guard<std::mutex> guard { m_curl_handles_lock };
+        std::lock_guard<std::mutex> guard { m_executors_lock };
         for (std::size_t i = 0; i < reserve_connections.value_or(0); ++i) {
-            m_curl_handles.push_back(curl_easy_init());
+            m_executors.push_back(Executor::make_unique(this));
         }
     }
 
@@ -227,11 +227,8 @@ EventLoop::~EventLoop()
     m_background_thread.join();
 
     {
-        std::lock_guard<std::mutex> guard { m_curl_handles_lock };
-        for (auto* curl_handle : m_curl_handles) {
-            curl_easy_cleanup(curl_handle);
-        }
-        m_curl_handles.clear();
+        std::lock_guard<std::mutex> guard { m_executors_lock };
+        m_executors.clear();
     }
 
     curl_multi_cleanup(m_cmh);
@@ -268,7 +265,8 @@ auto EventLoop::StartRequest(
     ++m_active_request_count;
 
     // Prepare now since it won't block the event loop thread.
-    auto executor_ptr = Executor::make(std::move(request_ptr), this);
+    auto executor_ptr = acquireExecutor();
+    executor_ptr->startAsync(std::move(request_ptr));
     executor_ptr->prepare();
     {
         std::lock_guard<std::mutex> guard { m_pending_requests_lock };
@@ -326,6 +324,8 @@ auto EventLoop::checkActions(
             completeRequestNormal(
                 *executor_ptr.get(),
                 Executor::convert(easy_result));
+
+            returnExecutor(std::move(executor_ptr));
         }
     }
 }
@@ -466,34 +466,33 @@ auto EventLoop::updateTimeouts() -> void
     }
 }
 
-auto EventLoop::acquireCurlHandle() -> CURL*
+auto EventLoop::acquireExecutor() -> std::unique_ptr<Executor>
 {
-    CURL* curl_handle { nullptr };
+    std::unique_ptr<Executor> executor_ptr { nullptr };
 
     {
-        std::lock_guard<std::mutex> guard { m_curl_handles_lock };
-        if (!m_curl_handles.empty()) {
-            curl_handle = m_curl_handles.back();
-            m_curl_handles.pop_back();
+        std::lock_guard<std::mutex> guard { m_executors_lock };
+        if (!m_executors.empty()) {
+            executor_ptr = std::move(m_executors.back());
+            m_executors.pop_back();
         }
     }
 
-    // Out of re-usable curl handles, create a new one outside the lock.
-    if (curl_handle == nullptr) {
-        curl_handle = curl_easy_init();
+    if (executor_ptr == nullptr) {
+        executor_ptr = Executor::make_unique(this);
     }
 
-    return curl_handle;
+    return executor_ptr;
 }
 
-auto EventLoop::returnCurlHandle(CURL* curl_handle) -> void
+auto EventLoop::returnExecutor(
+    std::unique_ptr<Executor> executor_ptr) -> void
 {
-    // reset documentation states share isn't removed
-    curl_easy_setopt(curl_handle, CURLOPT_SHARE, nullptr);
-    curl_easy_reset(curl_handle);
+    executor_ptr->reset();
+
     {
-        std::lock_guard<std::mutex> guard { m_curl_handles_lock };
-        m_curl_handles.push_back(curl_handle);
+        std::lock_guard<std::mutex> guard { m_executors_lock };
+        m_executors.push_back(std::move(executor_ptr));
     }
 }
 
@@ -637,7 +636,9 @@ auto on_uv_requests_accept_async(
 
     for (auto& executor_ptr : event_loop->m_grabbed_requests) {
 
-        // If this event loop is sharing curl information add it now.
+        // If this event loop is sharing curl information add it now, this is specifically done
+        // inside the event loop to reduce lock contention around adding the CURLOPT_SHARE setting
+        // as it will call the curl callback lock functions.
         if (event_loop->m_share_ptr != nullptr) {
             curl_easy_setopt(
                 executor_ptr->m_curl_handle,

--- a/test/EventLoopTest.hpp
+++ b/test/EventLoopTest.hpp
@@ -146,8 +146,6 @@ TEST_CASE("EventLoop Share Overlapping requests")
         }
     };
 
-    auto start = std::chrono::steady_clock::now();
-
     std::vector<std::thread> workers {};
     for (size_t i = 0; i < N_EVENT_LOOPS; ++i) {
         workers.emplace_back(worker_func);
@@ -158,8 +156,4 @@ TEST_CASE("EventLoop Share Overlapping requests")
     }
 
     REQUIRE(count == N_EVENT_LOOPS * N_REQUESTS);
-
-    auto stop = std::chrono::steady_clock::now();
-
-    std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count() << "\n";
 }


### PR DESCRIPTION
This removes the unnecessary Executor::make_unique()
when starting an asynchronous request.