### PR TITLE
async with std::future

### DIFF
--- a/.githooks/readme-template.md
+++ b/.githooks/readme-template.md
@@ -134,9 +134,9 @@ Here is how the benchmark application is called:
 ```bash
 $ ./examples/lift_benchmark --help
 Usage: ./examples/lift_benchmark<options> <url>
-    -c --connections  HTTP Connections to use.
-    -t --threads      Number of threads to use, connections are split
-                    evenly between each worker thread.
+    -c --connections  HTTP Connections to use per thread.
+    -t --threads      Number of threads to use.
+                      evenly between each worker thread.
     -d --duration     Duration of the test in seconds
     -h --help         Print this help usage.
 ```
@@ -156,7 +156,7 @@ Using `nginx` as the webserver with the default `fedora` configuration.
 
 File bug reports, feature requests and questions using [GitHub Issues](https://github.com/jbaldwin/liblifthttp/issues)
 
-Copyright © 2017-2020, Josh Baldwin
+Copyright © 2017-2021, Josh Baldwin
 
 [badge.language]: https://img.shields.io/badge/language-C%2B%2B17-yellow.svg
 [badge.license]: https://img.shields.io/badge/license-Apache--2.0-blue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ message("${PROJECT_NAME} LIFT_CODE_COVERAGE       = ${LIFT_CODE_COVERAGE}")
 message("${PROJECT_NAME} LIFT_USER_LINK_LIBRARIES = ${LIFT_USER_LINK_LIBRARIES}")
 
 set(LIBLIFTHTTP_SOURCE_FILES
+    inc/lift/impl/copy_util.hpp
+
     inc/lift/client.hpp src/client.cpp
     inc/lift/const.hpp
     inc/lift/escape.hpp src/escape.cpp

--- a/README.md
+++ b/README.md
@@ -38,28 +38,37 @@ int main()
     // This is the blocking synchronous HTTP call.
     auto response = request.perform();
     std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-    std::cout << response << "\n"; // Will print the raw http response.
+    std::cout << response << "\n\n"; // Will print the raw http response.
 
     // Creating the client starts it immediately, it spawns a background thread for executing requests.
     lift::client client{};
 
     // Create the request just like we did in the sync version, but now provide a lambda for on completion.
-    // NOTE: that the Lambda is executed ON the Lift client background thread.  If you want to handle
-    // on completion processing on this main thread you need to std::move() it back via a queue or inter-thread
-    // communication.  This is imporant if any resources are shared between the threads.
-    // NOTE: The request is created on the heap so ownership can be passed easily via an std::unique_ptr
-    // to the lift::client!  lift::request::make_unique() is a handy function to easily do so.
+    // NOTE: The Lambda is executed ON the Lift client background thread, not this main thread!
+    //       Use the std::promise + std::future async below if you want to pass ownership back to
+    //       this thread.
     auto request_ptr = lift::request::make_unique(
         "http://www.example.com",
         std::chrono::seconds{10}, // Give the request 10 seconds to complete or timeout.
         [](lift::request_ptr req_ptr, lift::response response) {
             std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-            std::cout << response << "\n";
+            std::cout << response << "\n\n";
         });
 
-    // Now inject the request into the client to be executed.  Moving into the client is required,
+    // Create a second async request that works via a promise+future instead of a functor callback.
+    auto request_with_promise_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
+    // Grab the requests future before submitting it into the lift client.
+    auto future = request_with_promise_ptr->async_future();
+
+    // Now inject the two async requests into the client to be executed.  Moving into the client is required,
     // this passes ownership of the request to the client's background worker thread.
     client.start_request(std::move(request_ptr));
+    client.start_request(std::move(request_with_promise_ptr));
+
+    // Block until the async request completes, this returns the original request and the response.
+    auto [req_ptr, resp] = future.get();
+    std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
+    std::cout << response << "\n\n"; // Will print the raw http response.
 
     // Block on this main thread until the lift client has completed the request, or timed out.
     while (!client.empty())

--- a/README.md
+++ b/README.md
@@ -33,46 +33,49 @@ to get your started on using liblifthttp with both the synchronous and asynchron
 
 int main()
 {
+    // Every HTTP request in this example has a 10 second timeout to complete.
     std::chrono::seconds timeout{10};
 
-    // Synchronous requests can be created on the stack with a 10 second timeout.
+    // Synchronous requests can be created on the stack.
     lift::request sync_request{"http://www.example.com", timeout};
 
-    // This is the blocking synchronous HTTP call, this thread will wait until completed or timeout.
+    // This is the blocking synchronous HTTP call, this thread will wait until the http request
+    // completes or times out.
     auto sync_response = sync_request.perform();
-    std::cout << "Lift status: " << lift::to_string(sync_response.lift_status()) << "\n";
+    std::cout << "Lift status (sync): " << lift::to_string(sync_response.lift_status()) << "\n";
     std::cout << sync_response << "\n\n"; // Will print the raw http response.
 
-    // Creating the client starts it immediately, it spawns a background thread for executing
-    // requests asynchronously and also allows for re-using http connections if possible.
+    // Asynchronous requests must be created on the heap, but they also need to be executed through
+    // a lift::client instance.  Creating a lift::client automatically spawns a background event
+    // loop thread to exceute the http requests it is given.  A lift::client also maintains a set
+    // of http connections and will actively re-use connections when possible.
     lift::client client{};
 
-    // Asynchronous requests need to be created on the heap, this request will be fulfilled by
-    // a std::future once.  Its ownership is first transferred into the lift::client while processing
-    // and is transferred back upon completion or timeout.
+    // Create an asynchronous request that will be fulfilled by a std::future upon its completion.
     auto async_future_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
-    // If you need a little more control or don't want to block on a std::future then the API allows
-    // for the lift::client to invoke a lambda function upon completing or timing out a request.
-    // It is important to note that the lambda will execute on the lift::client's background
-    // event loop thread, avoid any heavy CPU usage in the lambda otherwise it will block other
-    // outstanding requests from completing.
+    // Create an asynchronous request that will be fulfilled by a callback upon its completion.
+    // It is important to note that the callback will be executed on the lift::client's background
+    // event loop thread so it is wise to avoid any heavy CPU usage within this callback otherwise
+    // other outstanding requests will be blocked from completing.
     auto async_callback_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
-    // Now inject the two async requests into the client to be executed.  Moving into the client is
-    // required as this passes ownership of the request to the client's background worker thread
-    // while its being processed.  If you hold on to any raw pointers or references to the request
-    // after transferring ownership be sure to *not* use them until the request is completed, modifying
+    // Starting the asynchronous requests requires the request ownership to be moved to the
+    // lift::client while it is being processed.  Regardless of the on complet method, future or
+    // callback, the original request object and its response will have their ownership moved back
+    // to you upon completion.  If you hold on to any raw pointers or rerefences to the requests
+    // while they are being processed be sure not to use them until the requests complete, modifying
     // a requests state during execution is prohibited.
 
     // Start the request that will be completed by future.
     auto future = client.start_request(std::move(async_future_request));
 
-    // Start the request that will be completed by callback lambda.
+    // Start the request that will be completed by callback.
     client.start_request(
         std::move(async_callback_request),
         [](lift::request_ptr async_callback_request_returned, lift::response async_callback_response) {
-            std::cout << "Lift status: " << lift::to_string(async_callback_response.lift_status()) << "\n";
+            std::cout << "Lift status (async callback): ";
+            std::cout << lift::to_string(async_callback_response.lift_status()) << "\n";
             std::cout << async_callback_response << "\n\n";
         });
 
@@ -80,10 +83,11 @@ int main()
     // Note that the other callback request could complete and print to stdout before or after the future
     // request since it's lambda callback will be invoked on the lift::client's thread.
     auto [async_future_request_returned, async_future_response] = future.get();
-    std::cout << "Lift status: " << lift::to_string(async_future_response.lift_status()) << "\n";
-    std::cout << async_future_response << "\n\n"; // Will print the raw http response.
+    std::cout << "Lift status (async future): ";
+    std::cout << lift::to_string(async_future_response.lift_status()) << "\n";
+    std::cout << async_future_response << "\n\n";
 
-    // The lift::client destructor will block until all outstanding requests complete.
+    // The lift::client destructor will block until all outstanding requests complete or timeout.
 
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ int main()
     // Asynchronous requests need to be created on the heap, this request will be fulfilled by
     // a std::future once.  Its ownership is first transferred into the lift::client while processing
     // and is transferred back upon completion or timeout.
-    auto async_future_request = lift::request::make_unique("http://www.example.com", timeout);
+    auto async_future_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
     // If you need a little more control or don't want to block on a std::future then the API allows
     // for the lift::client to invoke a lambda function upon completing or timing out a request.
     // It is important to note that the lambda will execute on the lift::client's background
     // event loop thread, avoid any heavy CPU usage in the lambda otherwise it will block other
     // outstanding requests from completing.
-    auto async_callback_request = lift::request::make_unique("http://www.example.com", timeout);
+    auto async_callback_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
     // Now inject the two async requests into the client to be executed.  Moving into the client is
     // required as this passes ownership of the request to the client's background worker thread

--- a/README.md
+++ b/README.md
@@ -44,30 +44,34 @@ int main()
     lift::client client{};
 
     // Create the request just like we did in the sync version, but now provide a lambda for on completion.
+    // The lambda is provided when the request is started on the client.
     // NOTE: The Lambda is executed ON the Lift client background thread, not this main thread!
     //       Use the std::promise + std::future async below if you want to pass ownership back to
     //       this thread.
-    auto request_ptr = lift::request::make_unique(
-        "http://www.example.com", std::chrono::seconds{10}); // Give the request 10 seconds to complete or timeout
+    // This request is given 10 seconds to complete or timeout
+    auto request_with_callback_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
 
     // Create a second async request that works via a promise+future instead of a functor callback.
     auto request_with_future_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
 
     // Now inject the two async requests into the client to be executed.  Moving into the client is required,
     // this passes ownership of the request to the client's background worker thread.
-    client.start_request(std::move(request_ptr), [](lift::request_ptr req_ptr, lift::response response) {
+    client.start_request(std::move(request_with_callback_ptr), [](lift::request_ptr req_ptr, lift::response response) {
         std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
         std::cout << response << "\n\n";
     });
 
+    // Inject the future request
     auto future = client.start_request(std::move(request_with_future_ptr));
 
-    // Block until the async request completes, this returns the original request and the response.
+    // Block until the future async request completes, this returns the original request and the response.
+    // Note that the callback request could complete and print to stdout before or after since it is
+    // running on the lift client thread and not here.
     auto [req_ptr, resp] = future.get();
     std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
     std::cout << response << "\n\n"; // Will print the raw http response.
 
-    // Block on this main thread until the lift client has completed the request, or timed out.
+    // Block on this main thread until the lift client has completed all requests, or timed out.
     while (!client.empty())
     {
         std::this_thread::sleep_for(std::chrono::milliseconds{10});

--- a/README.md
+++ b/README.md
@@ -48,22 +48,19 @@ int main()
     //       Use the std::promise + std::future async below if you want to pass ownership back to
     //       this thread.
     auto request_ptr = lift::request::make_unique(
-        "http://www.example.com",
-        std::chrono::seconds{10}, // Give the request 10 seconds to complete or timeout.
-        [](lift::request_ptr req_ptr, lift::response response) {
-            std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-            std::cout << response << "\n\n";
-        });
+        "http://www.example.com", std::chrono::seconds{10}); // Give the request 10 seconds to complete or timeout
 
     // Create a second async request that works via a promise+future instead of a functor callback.
-    auto request_with_promise_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
-    // Grab the requests future before submitting it into the lift client.
-    auto future = request_with_promise_ptr->async_future();
+    auto request_with_future_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
 
     // Now inject the two async requests into the client to be executed.  Moving into the client is required,
     // this passes ownership of the request to the client's background worker thread.
-    client.start_request(std::move(request_ptr));
-    client.start_request(std::move(request_with_promise_ptr));
+    client.start_request(std::move(request_ptr), [](lift::request_ptr req_ptr, lift::response response) {
+        std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
+        std::cout << response << "\n\n";
+    });
+
+    auto future = client.start_request(std::move(request_with_future_ptr));
 
     // Block until the async request completes, this returns the original request and the response.
     auto [req_ptr, resp] = future.get();

--- a/examples/async_simple.cpp
+++ b/examples/async_simple.cpp
@@ -35,7 +35,7 @@ int main()
     for (auto& url : urls)
     {
         std::cout << "Requesting " << url << std::endl;
-        auto request_ptr = lift::request::make_unique(url, timeout);
+        auto request_ptr = std::make_unique<lift::request>(url, timeout);
         client.start_request(std::move(request_ptr), on_complete);
         timeout += 250ms;
         std::this_thread::sleep_for(50ms);

--- a/examples/async_simple.cpp
+++ b/examples/async_simple.cpp
@@ -35,8 +35,8 @@ int main()
     for (auto& url : urls)
     {
         std::cout << "Requesting " << url << std::endl;
-        auto request_ptr = lift::request::make_unique(url, timeout, on_complete);
-        client.start_request(std::move(request_ptr));
+        auto request_ptr = lift::request::make_unique(url, timeout);
+        client.start_request(std::move(request_ptr), on_complete);
         timeout += 250ms;
         std::this_thread::sleep_for(50ms);
     }

--- a/examples/benchmark.cpp
+++ b/examples/benchmark.cpp
@@ -11,8 +11,8 @@
 static auto print_usage(const std::string& program_name) -> void
 {
     std::cout << "Usage: " << program_name << "<options> <url>\n";
-    std::cout << "    -c --connections  HTTP Connections to use.\n";
-    std::cout << "    -t --threads      Number of threads to use, connections are split\n";
+    std::cout << "    -c --connections  HTTP Connections to use per thread.\n";
+    std::cout << "    -t --threads      Number of threads to use.\n";
     std::cout << "                      evenly between each worker thread.\n";
     std::cout << "    -d --duration     Duration of the test in seconds\n";
     std::cout << "    -h --help         Print this help usage.\n";
@@ -99,37 +99,44 @@ int main(int argc, char* argv[])
     std::atomic<uint64_t> error{0};
 
     {
+        std::vector<lift::request::async_callback_type> callbacks;
+        callbacks.reserve(threads);
         std::vector<std::unique_ptr<lift::client>> clients;
+        clients.reserve(threads);
+
         for (uint64_t i = 0; i < threads; ++i)
         {
-            auto client_ptr = std::make_unique<lift::client>();
+            clients.emplace_back(std::make_unique<lift::client>());
+
+            callbacks.emplace_back(
+                [&clients, &success, &error, &callbacks, i](lift::request_ptr req_ptr, lift::response response) {
+                    if (response.lift_status() == lift::lift_status::success)
+                    {
+                        success.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    else if (response.lift_status() == lift::lift_status::error_failed_to_start)
+                    {
+                        return;
+                    }
+                    else
+                    {
+                        error.fetch_add(1, std::memory_order_relaxed);
+                    }
+
+                    // And request again until we are shutting down.
+                    auto copy_callback = callbacks[i];
+                    clients[i]->start_request(std::move(req_ptr), std::move(copy_callback));
+                });
 
             for (uint64_t j = 0; j < connections; ++j)
             {
-                auto& client = *client_ptr;
-
                 auto request_ptr = lift::request::make_unique(url, 30s);
 
                 request_ptr->follow_redirects(false);
                 request_ptr->header("Connection", "Keep-Alive");
-                client_ptr->start_request(
-                    std::move(request_ptr),
-                    [&client, &success, &error](lift::request_ptr req_ptr, lift::response response) {
-                        if (response.lift_status() == lift::lift_status::success)
-                        {
-                            success.fetch_add(1, std::memory_order_relaxed);
-                        }
-                        else
-                        {
-                            error.fetch_add(1, std::memory_order_relaxed);
-                        }
-
-                        // And request again until we are shutting down.
-                        client.start_request(std::move(req_ptr));
-                    });
+                auto copy_callback = callbacks[i];
+                clients[i]->start_request(std::move(request_ptr), std::move(copy_callback));
             }
-
-            clients.emplace_back(std::move(client_ptr));
         }
 
         std::this_thread::sleep_for(duration);

--- a/examples/benchmark.cpp
+++ b/examples/benchmark.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
 
             for (uint64_t j = 0; j < connections; ++j)
             {
-                auto request_ptr = lift::request::make_unique(url, 30s);
+                auto request_ptr = std::make_unique<lift::request>(url, 30s);
 
                 request_ptr->follow_redirects(false);
                 request_ptr->header("Connection", "Keep-Alive");

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -20,14 +20,14 @@ int main()
     // Asynchronous requests need to be created on the heap, this request will be fulfilled by
     // a std::future once.  Its ownership is first transferred into the lift::client while processing
     // and is transferred back upon completion or timeout.
-    auto async_future_request = lift::request::make_unique("http://www.example.com", timeout);
+    auto async_future_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
     // If you need a little more control or don't want to block on a std::future then the API allows
     // for the lift::client to invoke a lambda function upon completing or timing out a request.
     // It is important to note that the lambda will execute on the lift::client's background
     // event loop thread, avoid any heavy CPU usage in the lambda otherwise it will block other
     // outstanding requests from completing.
-    auto async_callback_request = lift::request::make_unique("http://www.example.com", timeout);
+    auto async_callback_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
     // Now inject the two async requests into the client to be executed.  Moving into the client is
     // required as this passes ownership of the request to the client's background worker thread

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -3,46 +3,49 @@
 
 int main()
 {
+    // Every HTTP request in this example has a 10 second timeout to complete.
     std::chrono::seconds timeout{10};
 
-    // Synchronous requests can be created on the stack with a 10 second timeout.
+    // Synchronous requests can be created on the stack.
     lift::request sync_request{"http://www.example.com", timeout};
 
-    // This is the blocking synchronous HTTP call, this thread will wait until completed or timeout.
+    // This is the blocking synchronous HTTP call, this thread will wait until the http request
+    // completes or times out.
     auto sync_response = sync_request.perform();
-    std::cout << "Lift status: " << lift::to_string(sync_response.lift_status()) << "\n";
+    std::cout << "Lift status (sync): " << lift::to_string(sync_response.lift_status()) << "\n";
     std::cout << sync_response << "\n\n"; // Will print the raw http response.
 
-    // Creating the client starts it immediately, it spawns a background thread for executing
-    // requests asynchronously and also allows for re-using http connections if possible.
+    // Asynchronous requests must be created on the heap, but they also need to be executed through
+    // a lift::client instance.  Creating a lift::client automatically spawns a background event
+    // loop thread to exceute the http requests it is given.  A lift::client also maintains a set
+    // of http connections and will actively re-use connections when possible.
     lift::client client{};
 
-    // Asynchronous requests need to be created on the heap, this request will be fulfilled by
-    // a std::future once.  Its ownership is first transferred into the lift::client while processing
-    // and is transferred back upon completion or timeout.
+    // Create an asynchronous request that will be fulfilled by a std::future upon its completion.
     auto async_future_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
-    // If you need a little more control or don't want to block on a std::future then the API allows
-    // for the lift::client to invoke a lambda function upon completing or timing out a request.
-    // It is important to note that the lambda will execute on the lift::client's background
-    // event loop thread, avoid any heavy CPU usage in the lambda otherwise it will block other
-    // outstanding requests from completing.
+    // Create an asynchronous request that will be fulfilled by a callback upon its completion.
+    // It is important to note that the callback will be executed on the lift::client's background
+    // event loop thread so it is wise to avoid any heavy CPU usage within this callback otherwise
+    // other outstanding requests will be blocked from completing.
     auto async_callback_request = std::make_unique<lift::request>("http://www.example.com", timeout);
 
-    // Now inject the two async requests into the client to be executed.  Moving into the client is
-    // required as this passes ownership of the request to the client's background worker thread
-    // while its being processed.  If you hold on to any raw pointers or references to the request
-    // after transferring ownership be sure to *not* use them until the request is completed, modifying
+    // Starting the asynchronous requests requires the request ownership to be moved to the
+    // lift::client while it is being processed.  Regardless of the on complet method, future or
+    // callback, the original request object and its response will have their ownership moved back
+    // to you upon completion.  If you hold on to any raw pointers or rerefences to the requests
+    // while they are being processed be sure not to use them until the requests complete, modifying
     // a requests state during execution is prohibited.
 
     // Start the request that will be completed by future.
     auto future = client.start_request(std::move(async_future_request));
 
-    // Start the request that will be completed by callback lambda.
+    // Start the request that will be completed by callback.
     client.start_request(
         std::move(async_callback_request),
         [](lift::request_ptr async_callback_request_returned, lift::response async_callback_response) {
-            std::cout << "Lift status: " << lift::to_string(async_callback_response.lift_status()) << "\n";
+            std::cout << "Lift status (async callback): ";
+            std::cout << lift::to_string(async_callback_response.lift_status()) << "\n";
             std::cout << async_callback_response << "\n\n";
         });
 
@@ -50,10 +53,11 @@ int main()
     // Note that the other callback request could complete and print to stdout before or after the future
     // request since it's lambda callback will be invoked on the lift::client's thread.
     auto [async_future_request_returned, async_future_response] = future.get();
-    std::cout << "Lift status: " << lift::to_string(async_future_response.lift_status()) << "\n";
-    std::cout << async_future_response << "\n\n"; // Will print the raw http response.
+    std::cout << "Lift status (async future): ";
+    std::cout << lift::to_string(async_future_response.lift_status()) << "\n";
+    std::cout << async_future_response << "\n\n";
 
-    // The lift::client destructor will block until all outstanding requests complete.
+    // The lift::client destructor will block until all outstanding requests complete or timeout.
 
     return 0;
 }

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -14,30 +14,34 @@ int main()
     lift::client client{};
 
     // Create the request just like we did in the sync version, but now provide a lambda for on completion.
+    // The lambda is provided when the request is started on the client.
     // NOTE: The Lambda is executed ON the Lift client background thread, not this main thread!
     //       Use the std::promise + std::future async below if you want to pass ownership back to
     //       this thread.
-    auto request_ptr = lift::request::make_unique(
-        "http://www.example.com", std::chrono::seconds{10}); // Give the request 10 seconds to complete or timeout
+    // This request is given 10 seconds to complete or timeout
+    auto request_with_callback_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
 
     // Create a second async request that works via a promise+future instead of a functor callback.
     auto request_with_future_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
 
     // Now inject the two async requests into the client to be executed.  Moving into the client is required,
     // this passes ownership of the request to the client's background worker thread.
-    client.start_request(std::move(request_ptr), [](lift::request_ptr req_ptr, lift::response response) {
+    client.start_request(std::move(request_with_callback_ptr), [](lift::request_ptr req_ptr, lift::response response) {
         std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
         std::cout << response << "\n\n";
     });
 
+    // Inject the future request
     auto future = client.start_request(std::move(request_with_future_ptr));
 
-    // Block until the async request completes, this returns the original request and the response.
+    // Block until the future async request completes, this returns the original request and the response.
+    // Note that the callback request could complete and print to stdout before or after since it is
+    // running on the lift client thread and not here.
     auto [req_ptr, resp] = future.get();
     std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
     std::cout << response << "\n\n"; // Will print the raw http response.
 
-    // Block on this main thread until the lift client has completed the request, or timed out.
+    // Block on this main thread until the lift client has completed all requests, or timed out.
     while (!client.empty())
     {
         std::this_thread::sleep_for(std::chrono::milliseconds{10});

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -3,49 +3,57 @@
 
 int main()
 {
-    // Synchronous requests can be created on the stack.
-    lift::request request{"http://www.example.com"};
-    // This is the blocking synchronous HTTP call.
-    auto response = request.perform();
-    std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-    std::cout << response << "\n\n"; // Will print the raw http response.
+    std::chrono::seconds timeout{10};
 
-    // Creating the client starts it immediately, it spawns a background thread for executing requests.
+    // Synchronous requests can be created on the stack with a 10 second timeout.
+    lift::request sync_request{"http://www.example.com", timeout};
+
+    // This is the blocking synchronous HTTP call, this thread will wait until completed or timeout.
+    auto sync_response = sync_request.perform();
+    std::cout << "Lift status: " << lift::to_string(sync_response.lift_status()) << "\n";
+    std::cout << sync_response << "\n\n"; // Will print the raw http response.
+
+    // Creating the client starts it immediately, it spawns a background thread for executing
+    // requests asynchronously and also allows for re-using http connections if possible.
     lift::client client{};
 
-    // Create the request just like we did in the sync version, but now provide a lambda for on completion.
-    // The lambda is provided when the request is started on the client.
-    // NOTE: The Lambda is executed ON the Lift client background thread, not this main thread!
-    //       Use the std::promise + std::future async below if you want to pass ownership back to
-    //       this thread.
-    // This request is given 10 seconds to complete or timeout
-    auto request_with_callback_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
+    // Asynchronous requests need to be created on the heap, this request will be fulfilled by
+    // a std::future once.  Its ownership is first transferred into the lift::client while processing
+    // and is transferred back upon completion or timeout.
+    auto async_future_request = lift::request::make_unique("http://www.example.com", timeout);
 
-    // Create a second async request that works via a promise+future instead of a functor callback.
-    auto request_with_future_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
+    // If you need a little more control or don't want to block on a std::future then the API allows
+    // for the lift::client to invoke a lambda function upon completing or timing out a request.
+    // It is important to note that the lambda will execute on the lift::client's background
+    // event loop thread, avoid any heavy CPU usage in the lambda otherwise it will block other
+    // outstanding requests from completing.
+    auto async_callback_request = lift::request::make_unique("http://www.example.com", timeout);
 
-    // Now inject the two async requests into the client to be executed.  Moving into the client is required,
-    // this passes ownership of the request to the client's background worker thread.
-    client.start_request(std::move(request_with_callback_ptr), [](lift::request_ptr req_ptr, lift::response response) {
-        std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-        std::cout << response << "\n\n";
-    });
+    // Now inject the two async requests into the client to be executed.  Moving into the client is
+    // required as this passes ownership of the request to the client's background worker thread
+    // while its being processed.  If you hold on to any raw pointers or references to the request
+    // after transferring ownership be sure to *not* use them until the request is completed, modifying
+    // a requests state during execution is prohibited.
 
-    // Inject the future request
-    auto future = client.start_request(std::move(request_with_future_ptr));
+    // Start the request that will be completed by future.
+    auto future = client.start_request(std::move(async_future_request));
 
-    // Block until the future async request completes, this returns the original request and the response.
-    // Note that the callback request could complete and print to stdout before or after since it is
-    // running on the lift client thread and not here.
-    auto [req_ptr, resp] = future.get();
-    std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-    std::cout << response << "\n\n"; // Will print the raw http response.
+    // Start the request that will be completed by callback lambda.
+    client.start_request(
+        std::move(async_callback_request),
+        [](lift::request_ptr async_callback_request_returned, lift::response async_callback_response) {
+            std::cout << "Lift status: " << lift::to_string(async_callback_response.lift_status()) << "\n";
+            std::cout << async_callback_response << "\n\n";
+        });
 
-    // Block on this main thread until the lift client has completed all requests, or timed out.
-    while (!client.empty())
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
-    }
+    // Block until the async future request completes, this returns the original request and the response.
+    // Note that the other callback request could complete and print to stdout before or after the future
+    // request since it's lambda callback will be invoked on the lift::client's thread.
+    auto [async_future_request_returned, async_future_response] = future.get();
+    std::cout << "Lift status: " << lift::to_string(async_future_response.lift_status()) << "\n";
+    std::cout << async_future_response << "\n\n"; // Will print the raw http response.
+
+    // The lift::client destructor will block until all outstanding requests complete.
 
     return 0;
 }

--- a/examples/readme.cpp
+++ b/examples/readme.cpp
@@ -8,28 +8,37 @@ int main()
     // This is the blocking synchronous HTTP call.
     auto response = request.perform();
     std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-    std::cout << response << "\n"; // Will print the raw http response.
+    std::cout << response << "\n\n"; // Will print the raw http response.
 
     // Creating the client starts it immediately, it spawns a background thread for executing requests.
     lift::client client{};
 
     // Create the request just like we did in the sync version, but now provide a lambda for on completion.
-    // NOTE: that the Lambda is executed ON the Lift client background thread.  If you want to handle
-    // on completion processing on this main thread you need to std::move() it back via a queue or inter-thread
-    // communication.  This is imporant if any resources are shared between the threads.
-    // NOTE: The request is created on the heap so ownership can be passed easily via an std::unique_ptr
-    // to the lift::client!  lift::request::make_unique() is a handy function to easily do so.
+    // NOTE: The Lambda is executed ON the Lift client background thread, not this main thread!
+    //       Use the std::promise + std::future async below if you want to pass ownership back to
+    //       this thread.
     auto request_ptr = lift::request::make_unique(
         "http://www.example.com",
         std::chrono::seconds{10}, // Give the request 10 seconds to complete or timeout.
         [](lift::request_ptr req_ptr, lift::response response) {
             std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
-            std::cout << response << "\n";
+            std::cout << response << "\n\n";
         });
 
-    // Now inject the request into the client to be executed.  Moving into the client is required,
+    // Create a second async request that works via a promise+future instead of a functor callback.
+    auto request_with_promise_ptr = lift::request::make_unique("http://www.example.com", std::chrono::seconds{10});
+    // Grab the requests future before submitting it into the lift client.
+    auto future = request_with_promise_ptr->async_future();
+
+    // Now inject the two async requests into the client to be executed.  Moving into the client is required,
     // this passes ownership of the request to the client's background worker thread.
     client.start_request(std::move(request_ptr));
+    client.start_request(std::move(request_with_promise_ptr));
+
+    // Block until the async request completes, this returns the original request and the response.
+    auto [req_ptr, resp] = future.get();
+    std::cout << "Lift status: " << lift::to_string(response.lift_status()) << "\n";
+    std::cout << response << "\n\n"; // Will print the raw http response.
 
     // Block on this main thread until the lift client has completed the request, or timed out.
     while (!client.empty())

--- a/inc/lift/client.hpp
+++ b/inc/lift/client.hpp
@@ -297,7 +297,7 @@ private:
         m_active_request_count.fetch_add(amount, std::memory_order_release);
 
         {
-            std::scoped_lock lk{m_pending_requests_lock};
+            std::scoped_lock<std::mutex> lk{m_pending_requests_lock};
             m_pending_requests.reserve(m_pending_requests.size() + amount);
             for (auto& request_ptr : requests)
             {

--- a/inc/lift/client.hpp
+++ b/inc/lift/client.hpp
@@ -363,10 +363,11 @@ private:
      * Completes a request to pass ownership back to the user land.
      * Manages internal state accordingly, always call this function rather
      * than the request->OnComplete() function directly.
-     * @param exe The request handle to complete.
+     * @param exe_ptr The request handle to complete.
      * @param status The status of the request when completing.
      */
     auto complete_request_normal(executor_ptr exe_ptr, lift_status status) -> void;
+
     auto complete_request_normal_common(executor& exe, lift_status status) -> void;
 
     /**

--- a/inc/lift/client.hpp
+++ b/inc/lift/client.hpp
@@ -88,10 +88,12 @@ public:
     [[nodiscard]] auto is_running() -> bool { return m_is_running.load(std::memory_order_acquire); }
 
     /**
-     * Stops the event loop from accepting new requests.  It will continue to process
-     * existing requests until they are completed.  Note that the ~client() will
+     * Stops the client's background event loop from accepting new requests.  It will continue to
+     * process existing requests until they are completed.  Note that the ~client() will
      * 'block' until all requests flush as the background even loop process thread
      * won't exit until they are all completed/timed-out/error'ed/etc.
+     *
+     * This function does not block, it only signals the client to stop accepting requests.
      */
     auto stop() -> void { m_is_stopping.exchange(true, std::memory_order_release); }
 
@@ -99,7 +101,7 @@ public:
      * @return Gets the number of active HTTP requests currently running.  This includes
      *         the number of pending requests that haven't been started yet (if any).
      */
-    [[nodiscard]] auto size() const -> uint64_t { return m_active_request_count.load(std::memory_order_relaxed); }
+    [[nodiscard]] auto size() const -> uint64_t { return m_active_request_count.load(std::memory_order_acquire); }
 
     /**
      * @return True if there are no requests pending or executing.
@@ -107,36 +109,108 @@ public:
     [[nodiscard]] auto empty() const -> bool { return size() == 0; }
 
     /**
-     * Adds a request to process.  The ownership of the request is transferred into the client's
-     * event loop during execution and returned to the user in the request's
-     * `async_callback_type` callback.
+     * Starts processing the given request.  The ownership of the request is transferred into the
+     * client's background event loop thread during execution and is returned to the user when
+     * the future is fulfilled.
      *
-     * This function is thread safe.
+     * This function is thread safe and can be called from any thread to start processing a request.
      *
+     * @throw std::runtime_error If the request_ptr is nullptr.
+     * @param request_ptr The request to process.
+     * @return A future that will be fulfilled upon the request completing processing.
+     */
+    [[nodiscard]] auto start_request(request_ptr&& request_ptr) -> request::async_future_type;
+
+    /**
+     * Starts processing the given request.  The ownership of the request is transferred into the
+     * client's background event loop thread during execution and is returned to the user when the
+     * on complete callback handler is invoked.
+     *
+     * This function is thread safe and can be called from any thread to start processing a request.
+     *
+     * @throw std::runtime_error If the request_ptr or callback are nullptr.
      * @param request_ptr The request to process.  This request will have its OnComplete() handler
      *                    called when its completed/error'ed/etc.
      */
-    auto start_request(request_ptr request_ptr, request::async_callback_type callback) -> bool;
+    auto start_request(request_ptr&& request_ptr, request::async_callback_type callback) -> void;
 
-    auto start_request(request_ptr request_ptr) -> request::async_future_type;
-
-private:
-    auto start_request_common(request_ptr request_ptr) -> bool;
-
-public:
     /**
-     * Adds a batch of requests to process.  The requests in the container will be moved
-     * out of the container and into the client, ownership of the requests is transferred
-     * into th eevent loop during execution.
+     * Starts processing the set of given requests.  The ownership of the requests are transferred
+     * into the client's background event loop thread during execution and they are each individually
+     * returned to the user when each future is fulfilled.
      *
-     * This function is thread safe.
+     * This function is thread safe and can be called from any thread to start processing requests.
+     *
+     * Any requests that are given as nullptr will be ignored.
      *
      * @tparam container_type A container with a set of class lift::request_ptr.
      * @param requests The batch of requests to process.
-     * @return True if the requests were started.
+     * @return The set of futures for each request that was started.
      */
     template<typename container_type>
-    auto start_requests(container_type requests) -> bool;
+    auto start_requests(container_type&& requests) -> std::vector<request::async_future_type>
+    {
+        std::vector<request::async_future_type> futures{};
+        futures.reserve(std::size(requests));
+
+        size_t amount{std::size(requests)};
+
+        // Prep each request's future prior to acquiring the lock.
+        for (auto& request_ptr : requests)
+        {
+            if (request_ptr != nullptr)
+            {
+                futures.emplace_back(request_ptr->async_future());
+            }
+            else
+            {
+                --amount;
+            }
+        }
+
+        start_requests_common(std::move(requests), amount);
+        return futures;
+    }
+
+    /**
+     * Starts processing the set of given requests.  The ownership of the requests are transferred
+     * into the client's background event loop thread during execution and they are each individually
+     * returned to the user when their on complete callback is invoked.  Each request submitted via
+     * this function has the same callback used for each request.
+     *
+     * This function is thread safe and can be called from any thread to start processing requests.
+     *
+     * Any requests that are given as nullptr will be ignored.
+     *
+     * @throw std::runtime_error If the callback is nullptr.
+     * @tparam container_type A container with a set of class lift::request_ptr.
+     * @param requests The batch of requests to process.
+     */
+    template<typename container_type>
+    auto start_requests(container_type&& requests, request::async_callback_type callback) -> void
+    {
+        if (callback == nullptr)
+        {
+            throw std::runtime_error{"lift::client::start_requests (callback) The callback cannot be nullptr."};
+        }
+
+        size_t amount{std::size(requests)};
+
+        // Prep each request's callback prior to acquiring the lock.
+        for (auto& request_ptr : requests)
+        {
+            if (request_ptr != nullptr)
+            {
+                request_ptr->async_callback(callback);
+            }
+            else
+            {
+                --amount;
+            }
+        }
+
+        start_requests_common(std::move(requests), amount);
+    }
 
 private:
     /// Set to true if the client is currently running.
@@ -199,7 +273,78 @@ private:
     /// Functor to call on background thread start/stop.
     on_thread_callback_type m_on_thread_callback{nullptr};
 
-    /// The background thread runs from this function.
+    /**
+     * Common code between future and callback start request functions.
+     */
+    auto start_request_common(request_ptr&& request_ptr) -> void;
+
+    /**
+     * Common code between future and callback start requests functions.
+     */
+    template<typename container_type>
+    auto start_requests_common(container_type&& requests, size_t amount) -> void
+    {
+        // Whoops, this client is actually shutting down.
+        if (m_is_stopping.load(std::memory_order_acquire))
+        {
+            for (auto& request_ptr : requests)
+            {
+                start_request_notify_failed_start(std::move(request_ptr));
+            }
+            return;
+        }
+
+        m_active_request_count.fetch_add(amount, std::memory_order_release);
+
+        {
+            std::scoped_lock lk{m_pending_requests_lock};
+            m_pending_requests.reserve(m_pending_requests.size() + amount);
+            for (auto& request_ptr : requests)
+            {
+                if (request_ptr != nullptr)
+                {
+                    m_pending_requests.emplace_back(std::move(request_ptr));
+                }
+            }
+        }
+
+        // Notify the event loop thread that there are requests waiting to be picked up.
+        uv_async_send(&m_uv_async);
+    }
+
+    /**
+     * Utility function to notify the user correctly when a request fails to start.
+     */
+    static auto start_request_notify_failed_start(request_ptr&& request_ptr) -> void
+    {
+        response r{};
+
+        r.m_lift_status = lift_status::error_failed_to_start;
+
+        // This http status code isn't perfect, but its better than nothing I think?
+        r.m_status_code   = lift::http::status_code::http_500_internal_server_error;
+        r.m_total_time    = 0;
+        r.m_num_connects  = 0;
+        r.m_num_redirects = 0;
+
+        auto& on_complete_handler = request_ptr->m_on_complete_handler.m_object.value();
+
+        if (std::holds_alternative<request::async_callback_type>(on_complete_handler))
+        {
+            auto& callback = std::get<request::async_callback_type>(on_complete_handler);
+            callback(std::move(request_ptr), std::move(r));
+        }
+        else if (std::holds_alternative<request::async_promise_type>(on_complete_handler))
+        {
+            auto& promise = std::get<request::async_promise_type>(on_complete_handler);
+            promise.set_value(std::make_pair(std::move(request_ptr), std::move(r)));
+        }
+        // else do nothing for std::monostate, no way to actually report the client is shutting down.
+    }
+
+    /*
+     * The background event loop thread runs from this function.
+     */
     auto run() -> void;
 
     /**
@@ -333,39 +478,5 @@ private:
 
     friend auto on_uv_timesup_callback(uv_timer_t* handle) -> void;
 };
-
-template<typename container_type>
-auto client::start_requests(container_type requests) -> bool
-{
-    if (m_is_stopping.load(std::memory_order_acquire))
-    {
-        return false;
-    }
-
-    m_active_request_count.fetch_add(std::size(requests), std::memory_order_relaxed);
-
-    for (auto& [request_ptr, callback] : requests)
-    {
-        request_ptr->async_callback(std::move(callback));
-    }
-
-    // Lock scope
-    {
-        std::lock_guard<std::mutex> guard(m_pending_requests_lock);
-        for (auto& [request_ptr, moved_already] : requests)
-        {
-            if (request_ptr == nullptr)
-            {
-                continue;
-            }
-            m_pending_requests.emplace_back(std::move(request_ptr));
-        }
-    }
-
-    // Notify the event loop thread that there are requests waiting to be picked up.
-    uv_async_send(&m_uv_async);
-
-    return true;
-}
 
 } // namespace lift

--- a/inc/lift/client.hpp
+++ b/inc/lift/client.hpp
@@ -107,9 +107,9 @@ public:
     [[nodiscard]] auto empty() const -> bool { return size() == 0; }
 
     /**
-     * Adds a request to process.  The ownership of the request is trasferred into
-     * the event loop during execution and returned to the client in the
-     * OnCompletHandlerType callback.
+     * Adds a request to process.  The ownership of the request is transferred into the client's
+     * event loop during execution and returned to the user in the request's
+     * `on_thread_callback_type` callback.
      *
      * This function is thread safe.
      *
@@ -122,12 +122,13 @@ public:
     /**
      * Adds a batch of requests to process.  The requests in the container will be moved
      * out of the container and into the client, ownership of the requests is transferred
-     * into th event loop during execution.
+     * into th eevent loop during execution.
      *
      * This function is thread safe.
      *
-     * @tparam container_type A container of class lift::request_ptr.
+     * @tparam container_type A container with a set of class lift::request_ptr.
      * @param requests The batch of requests to process.
+     * @return True if the requests were started.
      */
     template<typename container_type>
     auto start_requests(container_type requests) -> bool;
@@ -215,13 +216,15 @@ private:
      * @param exe The request handle to complete.
      * @param status The status of the request when completing.
      */
-    auto complete_request_normal(executor& exe, lift_status status) -> void;
+    auto complete_request_normal(executor_ptr exe_ptr, lift_status status) -> void;
+    auto complete_request_normal_common(executor& exe, lift_status status) -> void;
 
     /**
      * Completes a request that has timed out but still has connection time remaining.
      * @param exe The request to timeout.
      */
     auto complete_request_timeout(executor& exe) -> void;
+    auto complete_request_timeout_common(executor& exe) -> request_ptr;
 
     /**
      * Adds the request with the appropriate timeout.

--- a/inc/lift/executor.hpp
+++ b/inc/lift/executor.hpp
@@ -61,8 +61,8 @@ private:
     request_ptr m_request_async{nullptr};
     /// If the async request has a timeout set then this is the position to delete when completed.
     std::optional<std::multimap<uint64_t, executor*>::iterator> m_timeout_iterator{};
-    // Has the on complete callback been called already?
-    bool m_on_complete_callback_called{false};
+    // Has the on complete handler already been processed?
+    bool m_on_complete_handler_processed{false};
 
     /// Used internally to point at one of the sync or async requests.
     request* m_request{nullptr};

--- a/inc/lift/impl/copy_util.hpp
+++ b/inc/lift/impl/copy_util.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+
+namespace lift::impl
+{
+/**
+ * This class is a work-around in that std::function does not support move only types.
+ * std::promise<T> is move only, and during a times up event it needs to be 'moved' to the client
+ * via a custom copy/move.  This type is pretty ugly but its only used for this one use-case.
+ *
+ * Other viable solutions could be implementing a custom function type that works for move only types
+ * or taking a performance hit at runtime and wrapping the std::promise in an std::shared_ptr.
+ */
+template<typename T>
+struct copy_but_actually_move
+{
+    explicit copy_but_actually_move(T t) : m_object(std::move(t)) {}
+    ~copy_but_actually_move() = default;
+
+    copy_but_actually_move(const copy_but_actually_move<T>& other) : m_object(std::move(other.m_object)) {}
+    copy_but_actually_move(copy_but_actually_move<T>&& other) : m_object(std::move(other.m_object)) {}
+
+    auto operator=(const copy_but_actually_move<T>& other) -> copy_but_actually_move<T>&
+    {
+        if (std::addressof(other) != this)
+        {
+            m_object = std::move(other.m_object);
+        }
+        return *this;
+    }
+
+    auto operator=(copy_but_actually_move<T>&& other) -> copy_but_actually_move<T>&
+    {
+        if (std::addressof(other) != this)
+        {
+            m_object = std::move(other.m_object);
+        }
+        return *this;
+    }
+
+    mutable std::optional<T> m_object{std::nullopt};
+};
+
+} // namespace lift::impl

--- a/inc/lift/request.hpp
+++ b/inc/lift/request.hpp
@@ -103,14 +103,14 @@ public:
      * @param request_ptr Passes ownership of the request back to the user of liblifthttp.
      * @param response Response of the request_ptr.
      */
-    using on_complete_callback_type = std::function<void(std::unique_ptr<request> request_ptr, response response)>;
+    using async_callback_type = std::function<void(std::unique_ptr<request> request_ptr, response response)>;
+    using async_future_type   = std::future<std::pair<std::unique_ptr<request>, response>>;
 
-    using on_complete_promise_type = std::promise<std::pair<std::unique_ptr<request>, response>>;
+private:
+    using async_promise_type  = std::promise<std::pair<std::unique_ptr<request>, response>>;
+    using async_handlers_type = std::variant<std::monostate, async_callback_type, async_promise_type>;
 
-    using on_complete_handler_type = std::variant<std::monostate, on_complete_callback_type, on_complete_promise_type>;
-
-    using async_future_type = std::future<std::pair<std::unique_ptr<request>, response>>;
-
+public:
     /**
      * Transfer progress handler callback signature.
      * @param download_total_bytes Total number of bytes the application should expect to download.
@@ -134,13 +134,8 @@ public:
      * @param url The url to request.
      * @param timeout An optional timeout for this request.  If not provided the request
      *                could hang/block forever if it is never responded to.
-     * @param on_complete_handler For asynchronous requests provide this if you want to
-     *                            know when the request completes with the response information.
      */
-    explicit request(
-        std::string                              url,
-        std::optional<std::chrono::milliseconds> timeout             = std::nullopt,
-        on_complete_handler_type                 on_complete_handler = std::monostate{});
+    explicit request(std::string url, std::optional<std::chrono::milliseconds> timeout = std::nullopt);
 
     /**
      * Creates a new request on the heap, this is a useful utility for asynchronous requests.
@@ -155,12 +150,10 @@ public:
      *                            a callback (runs on the client background thread) or via a
      *                            promise/future.
      */
-    static auto make_unique(
-        std::string                              url,
-        std::optional<std::chrono::milliseconds> timeout             = std::nullopt,
-        on_complete_handler_type                 on_complete_handler = std::monostate{}) -> std::unique_ptr<request>
+    static auto make_unique(std::string url, std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+        -> std::unique_ptr<request>
     {
-        return std::make_unique<request>(std::move(url), std::move(timeout), std::move(on_complete_handler));
+        return std::make_unique<request>(std::move(url), std::move(timeout));
     }
 
     request(const request&) = default;
@@ -178,38 +171,6 @@ public:
      * @return The HTTP response.
      */
     auto perform(share_ptr share_ptr = nullptr) -> response;
-
-    /**
-     * This on complete handler event is called when a request is executed asynchronously.  Provide
-     * either a functor to call or a promise that will be fulfilled.
-     *
-     * This is not used for synchronous requests, can only be used for asynchronous requests.
-     *
-     * @param on_complete_handler When this request completes this handle is called.
-     */
-    auto on_complete_handler(on_complete_handler_type on_complete_handler) -> void
-    {
-        m_on_complete_handler = copy_but_actually_move<on_complete_handler_type>(std::move(on_complete_handler));
-    }
-
-    /**
-     * @return The current on complete handler callback if set, otherwise nullptr.
-     */
-    auto on_complete_handler() const -> const on_complete_handler_type&
-    {
-        return m_on_complete_handler.m_object.value();
-    }
-
-    auto async_callback(on_complete_callback_type callback) -> void
-    {
-        m_on_complete_handler.m_object = {std::move(callback)};
-    }
-
-    auto async_future() -> async_future_type
-    {
-        m_on_complete_handler.m_object = {on_complete_promise_type{}};
-        return std::get<on_complete_promise_type>(m_on_complete_handler.m_object.value()).get_future();
-    }
 
     /**
      * Sets or unsets a transfer progress handler callback.  Called periodically to update the
@@ -502,8 +463,8 @@ public:
     }
 
 private:
-    /// The on complete handler callback or promise to fulfill.
-    copy_but_actually_move<on_complete_handler_type> m_on_complete_handler{std::monostate{}};
+    /// The on complete handler callback or promise to fulfill, this is only used for async requests.
+    copy_but_actually_move<async_handlers_type> m_on_complete_handler{std::monostate{}};
     /// The transfer progress handler callback.
     transfer_progress_handler_type m_on_transfer_progress_handler{nullptr};
     /// The timeout to connect, or none.
@@ -552,6 +513,23 @@ private:
     std::vector<lift::mime_field> m_mime_fields{};
     /// Happy eyeballs algorithm timeout https://curl.haxx.se/libcurl/c/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.html
     std::optional<std::chrono::milliseconds> m_happy_eyeballs_timeout{};
+
+    /**
+     * Used by the client to set an async callback for on completion notification to the user.
+     */
+    auto async_callback(async_callback_type callback) -> void
+    {
+        m_on_complete_handler.m_object = {std::move(callback)};
+    }
+
+    /**
+     * Used by the client to set an async future for on completion notification to the user.
+     */
+    auto async_future() -> async_future_type
+    {
+        m_on_complete_handler.m_object = {async_promise_type{}};
+        return std::get<async_promise_type>(m_on_complete_handler.m_object.value()).get_future();
+    }
 
     // libcurl will call this function if the user has requested transfer progress information.
     friend auto curl_xfer_info(

--- a/inc/lift/request.hpp
+++ b/inc/lift/request.hpp
@@ -116,10 +116,6 @@ public:
      * @param url The url to request.
      * @param timeout An optional timeout for this request.  If not provided the request
      *                could hang/block forever if it is never responded to.
-     * @param on_complete_handler For asynchronous requests provide this if you want to
-     *                            know when the request completes with the response information via
-     *                            a callback (runs on the client background thread) or via a
-     *                            promise/future.
      */
     static auto make_unique(std::string url, std::optional<std::chrono::milliseconds> timeout = std::nullopt)
         -> std::unique_ptr<request>

--- a/inc/lift/request.hpp
+++ b/inc/lift/request.hpp
@@ -2,6 +2,7 @@
 
 #include "lift/header.hpp"
 #include "lift/http.hpp"
+#include "lift/impl/copy_util.hpp"
 #include "lift/mime_field.hpp"
 #include "lift/resolve_host.hpp"
 #include "lift/response.hpp"
@@ -20,36 +21,6 @@ namespace lift
 {
 class client;
 class executor;
-
-template<typename T>
-struct copy_but_actually_move
-{
-    copy_but_actually_move(T t) : m_object(std::move(t)) {}
-    ~copy_but_actually_move() = default;
-
-    copy_but_actually_move(const copy_but_actually_move<T>& other) { m_object = std::move(other.m_object); }
-    copy_but_actually_move(copy_but_actually_move<T>&& other) { m_object = std::move(other.m_object); }
-
-    auto operator=(const copy_but_actually_move<T>& other) -> copy_but_actually_move<T>&
-    {
-        if (std::addressof(other) != this)
-        {
-            m_object = std::move(other.m_object);
-        }
-        return *this;
-    }
-
-    auto operator=(copy_but_actually_move<T>&& other) -> copy_but_actually_move<T>&
-    {
-        if (std::addressof(other) != this)
-        {
-            m_object = std::move(other.m_object);
-        }
-        return *this;
-    }
-
-    mutable std::optional<T> m_object{std::nullopt};
-};
 
 enum class ssl_certificate_type
 {
@@ -464,7 +435,7 @@ public:
 
 private:
     /// The on complete handler callback or promise to fulfill, this is only used for async requests.
-    copy_but_actually_move<async_handlers_type> m_on_complete_handler{std::monostate{}};
+    impl::copy_but_actually_move<async_handlers_type> m_on_complete_handler{std::monostate{}};
     /// The transfer progress handler callback.
     transfer_progress_handler_type m_on_transfer_progress_handler{nullptr};
     /// The timeout to connect, or none.

--- a/inc/lift/request.hpp
+++ b/inc/lift/request.hpp
@@ -116,9 +116,11 @@ public:
      * @param url The url to request.
      * @param timeout An optional timeout for this request.  If not provided the request
      *                could hang/block forever if it is never responded to.
+     * @deprecated Use std::make_unique<lift::request>()
      */
-    static auto make_unique(std::string url, std::optional<std::chrono::milliseconds> timeout = std::nullopt)
-        -> std::unique_ptr<request>
+    [[deprecated("Use std::make_unique<lift::request>() instead.")]] static auto
+        make_unique(std::string url, std::optional<std::chrono::milliseconds> timeout = std::nullopt)
+            -> std::unique_ptr<request>
     {
         return std::make_unique<request>(std::move(url), std::move(timeout));
     }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -84,7 +84,7 @@ auto on_uv_timesup_callback(uv_timer_t* handle) -> void;
 client::client(options opts)
     : m_connect_timeout(std::move(opts.connect_timeout)),
       m_curl_context_ready(),
-      m_resolve_hosts(std::move(opts.resolve_hosts.value_or(std::vector<resolve_host>{}))),
+      m_resolve_hosts(std::move(opts.resolve_hosts).value_or(std::vector<resolve_host>{})),
       m_share_ptr(std::move(opts.share)),
       m_on_thread_callback(std::move(opts.on_thread_callback))
 {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -119,11 +119,14 @@ client::client(options opts)
     m_background_thread = std::thread{[this] { run(); }};
 
     /**
-     * Spin wait for the thread to spin-up and run the event loop,
+     * 'Spin' wait for the thread to spin-up and run the event loop,
      * this means when the constructor returns the user can start adding requests
      * immediately without waiting.
      */
-    while (!is_running()) {}
+    while (!is_running())
+    {
+        std::this_thread::yield();
+    }
 }
 
 client::~client()
@@ -225,63 +228,112 @@ auto client::check_actions(curl_socket_t socket, int event_bitmask) -> void
             curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &exe);
             executor_ptr executor_ptr{exe};
 
+            // Remove the handle from curl multi since it is done processing.
             curl_multi_remove_handle(m_cmh, easy_handle);
 
-            complete_request_normal(*executor_ptr.get(), executor::convert(easy_result));
-
-            return_executor(std::move(executor_ptr));
+            // Notify the user (if it hasn't already timed out) that the request is completed.
+            // This will also return the executor to the pool for reuse.
+            complete_request_normal(std::move(executor_ptr), executor::convert(easy_result));
         }
     }
 }
 
-auto client::complete_request_normal(executor& exe, lift_status status) -> void
+auto client::complete_request_normal(executor_ptr exe_ptr, lift_status status) -> void
 {
-    if (exe.m_on_complete_callback_called == false)
+    auto& exe = *exe_ptr.get();
+
+    if (exe.m_on_complete_handler_processed == false)
     {
-        auto& on_complete_handler = exe.m_request_async->m_on_complete_handler;
+        // Don't run this logic twice ever.
+        exe.m_on_complete_handler_processed = true;
+        // Since the request completed remove it from the timeout set if it is there.
+        remove_timeout(exe);
 
-        if (on_complete_handler != nullptr)
+        auto& on_complete_handler = exe.m_request_async->m_on_complete_handler.m_object.value();
+
+        if (std::holds_alternative<request::on_complete_callback_type>(on_complete_handler))
         {
-            exe.m_on_complete_callback_called = true;
-            exe.m_response.m_lift_status      = status;
-            exe.copy_curl_to_response();
-            remove_timeout(exe);
+            complete_request_normal_common(exe, status);
 
-            on_complete_handler(std::move(exe.m_request_async), std::move(exe.m_response));
+            auto& callback = std::get<request::on_complete_callback_type>(on_complete_handler);
+            callback(std::move(exe.m_request_async), std::move(exe.m_response));
         }
+        else if (std::holds_alternative<request::on_complete_promise_type>(on_complete_handler))
+        {
+            complete_request_normal_common(exe, status);
+
+            auto& promise = std::get<request::on_complete_promise_type>(on_complete_handler);
+            promise.set_value(std::make_pair(std::move(exe.m_request_async), std::move(exe.m_response)));
+        }
+        // else do nothing for std::monostate, the user doesn't want to be notified.
     }
 
+    return_executor(std::move(exe_ptr));
     m_active_request_count.fetch_sub(1, std::memory_order_relaxed);
+}
+
+auto client::complete_request_normal_common(executor& exe, lift_status status) -> void
+{
+    exe.m_response.m_lift_status = status;
+    exe.copy_curl_to_response();
 }
 
 auto client::complete_request_timeout(executor& exe) -> void
 {
-    auto& on_complete_handler = exe.m_request_async->m_on_complete_handler;
+    /**
+     * NOTE: This function doesn't remove the request from the curl multi handle nor does it
+     *       return the executor to the pool.  That is because this function is still allowing
+     *       for curl to complete to establish http connections for extremely *low* timeout values.
+     *
+     *       This function expects that complete_request_normal will eventually be called by curl
+     *       to properly cleanup and finish the request and allow for the http connection to fully
+     *       establish.
+     */
 
     // Call on complete if it exists and hasn't been called before.
-    if (exe.m_on_complete_callback_called == false && on_complete_handler != nullptr)
+    if (exe.m_on_complete_handler_processed == false)
     {
-        exe.m_on_complete_callback_called = true;
-        exe.m_response.m_lift_status      = lift::lift_status::timeout;
-        exe.set_timesup_response(exe.m_request->timeout().value());
+        // Don't run this logic twice ever.
+        exe.m_on_complete_handler_processed = true;
+
+        auto& on_complete_handler = exe.m_request_async->m_on_complete_handler.m_object.value();
 
         // Removing the timesup is done in the uv timesup callback so it can prune
         // every single item that has timesup'ed.  Doing it here will cause 1 item
         // per loop iteration to be removed if there are multiple items with the same timesup value.
         // remove_timeout(exe);
 
-        // IMPORTANT! Copying here is required _OR_ shared ownership must be added as libcurl
-        // maintains char* type pointers into the request data structure.  There is no guarantee
-        // after moving into user land that it will stay alive long enough until curl finishes its
-        // own timeout.  Shared ownership would most likely require locks as well since any curl
-        // handle still in the curl multi handle could be mutated by curl at any moment, copying
-        // seems far safer.
-        auto copy_ptr = std::make_unique<request>(*exe.m_request_async);
+        if (std::holds_alternative<request::on_complete_callback_type>(on_complete_handler))
+        {
+            auto copy = complete_request_timeout_common(exe);
 
-        on_complete_handler(std::move(copy_ptr), std::move(exe.m_response));
+            auto& callback = std::get<request::on_complete_callback_type>(on_complete_handler);
+            callback(std::move(copy), std::move(exe.m_response));
+        }
+        else if (std::holds_alternative<request::on_complete_promise_type>(on_complete_handler))
+        {
+            auto copy = complete_request_timeout_common(exe);
+
+            auto& promise = std::get<request::on_complete_promise_type>(on_complete_handler);
+            promise.set_value(std::make_pair(std::move(copy), std::move(exe.m_response)));
+        }
+        // else do nothing for std::monostate, the user doesn't want to be notified.
     }
+}
 
-    // Lift timeouts do not trigger an active request count drop.
+auto client::complete_request_timeout_common(executor& exe) -> request_ptr
+{
+    exe.m_response.m_lift_status = lift::lift_status::timeout;
+    exe.set_timesup_response(exe.m_request->timeout().value());
+
+    // IMPORTANT! Copying here is required _OR_ shared ownership must be added as libcurl
+    // maintains char* type pointers into the request data structure.  There is no guarantee
+    // after moving into user land that it will stay alive long enough until curl finishes its
+    // own timeout.  Shared ownership would most likely require locks as well since any curl
+    // handle still in the curl multi handle could be mutated by curl at any moment, copying
+    // seems far safer.
+    auto copy_ptr = std::make_unique<request>(*exe.m_request_async);
+    return copy_ptr;
 }
 
 auto client::add_timeout(executor& exe) -> void
@@ -554,9 +606,9 @@ auto on_uv_requests_accept_async(uv_async_t* handle) -> void
         {
             /**
              * If curl_multi_add_handle fails then notify the user that the request failed to start
-             * immediately.
+             * immediately.  This will return the just acquired executor back into the pool.
              */
-            c->complete_request_normal(*executor_ptr.get(), executor::convert(CURLcode::CURLE_SEND_ERROR));
+            c->complete_request_normal(std::move(executor_ptr), executor::convert(CURLcode::CURLE_SEND_ERROR));
         }
         else
         {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -329,7 +329,7 @@ auto client::complete_request_timeout(executor& exe) -> void
 
         if (std::holds_alternative<request::async_callback_type>(on_complete_handler))
         {
-            // After copying the on complete handler has MOVED due to copy_but_actually_move.
+            // After copying the on complete handler has MOVED due to impl::copy_but_actually_move.
             // The type will be the same but the correct memory location must be used.
             auto copy = complete_request_timeout_common(exe);
 

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -386,7 +386,7 @@ auto executor::copy_curl_to_response() -> void
 {
     long http_response_code = 0;
     curl_easy_getinfo(m_curl_handle, CURLINFO_RESPONSE_CODE, &http_response_code);
-    m_response.m_status_code = http::to_enum(static_cast<int32_t>(http_response_code));
+    m_response.m_status_code = http::to_enum(static_cast<uint16_t>(http_response_code));
 
     long http_version = 0;
     curl_easy_getinfo(m_curl_handle, CURLINFO_HTTP_VERSION, &http_version);

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -445,8 +445,8 @@ auto executor::reset() -> void
     m_request       = nullptr;
 
     m_timeout_iterator.reset();
-    m_on_complete_callback_called = false;
-    m_response                    = response{};
+    m_on_complete_handler_processed = false;
+    m_response                      = response{};
 
     curl_easy_setopt(m_curl_handle, CURLOPT_SHARE, nullptr);
     m_curl_share_handle = nullptr;

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -36,11 +36,6 @@ auto request::perform(share_ptr share_ptr) -> response
     return exe.perform();
 }
 
-auto request::on_complete_handler(on_complete_handler_type on_complete_handler) -> void
-{
-    m_on_complete_handler = std::move(on_complete_handler);
-}
-
 auto request::transfer_progress_handler(std::optional<transfer_progress_handler_type> transfer_progress_handler) -> void
 {
     if (transfer_progress_handler.has_value() && transfer_progress_handler.value())

--- a/src/request.cpp
+++ b/src/request.cpp
@@ -22,10 +22,8 @@ auto to_string(ssl_certificate_type type) -> const std::string&
     }
 }
 
-request::request(
-    std::string url, std::optional<std::chrono::milliseconds> timeout, on_complete_handler_type on_complete_handler)
-    : m_on_complete_handler(std::move(on_complete_handler)),
-      m_timeout(std::move(timeout)),
+request::request(std::string url, std::optional<std::chrono::milliseconds> timeout)
+    : m_timeout(std::move(timeout)),
       m_url(std::move(url))
 {
 }

--- a/test/test_client.cpp
+++ b/test/test_client.cpp
@@ -6,8 +6,8 @@ TEST_CASE("client Start event loop, then stop and add a request.")
 {
     lift::client client{};
 
-    auto request =
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+    auto request = std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
     REQUIRE_NOTHROW(
         client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
@@ -15,8 +15,8 @@ TEST_CASE("client Start event loop, then stop and add a request.")
             REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
         }));
 
-    request =
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+    request = std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
     // Adding requests after stopping should return false that they cannot be started.
     client.stop();
@@ -33,12 +33,12 @@ TEST_CASE("client Start event loop, then stop and add multiple requests futures.
     lift::client client{};
 
     std::vector<lift::request_ptr> requests1;
-    requests1.emplace_back(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+    requests1.emplace_back(std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
     std::vector<lift::request_ptr> requests2;
-    requests2.emplace_back(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+    requests2.emplace_back(std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
     auto futures1 = client.start_requests(std::move(requests1));
     client.stop();
@@ -74,12 +74,12 @@ TEST_CASE("client Start event loop, then stop and add multiple requests callback
     };
 
     std::vector<lift::request_ptr> requests1;
-    requests1.emplace_back(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+    requests1.emplace_back(std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
     std::vector<lift::request_ptr> requests2;
-    requests2.emplace_back(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+    requests2.emplace_back(std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
     client.start_requests(std::move(requests1), callback1);
     client.stop();
@@ -97,8 +97,8 @@ TEST_CASE("client Provide nullptr lambda functor")
 {
     lift::client client{};
 
-    auto request =
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+    auto request = std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
     REQUIRE_THROWS(client.start_request(std::move(request), nullptr));
 }
@@ -108,8 +108,8 @@ TEST_CASE("client Provide nullptr lambda functor for batch requests")
     lift::client client{};
 
     std::vector<lift::request_ptr> requests{};
-    requests.emplace_back(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+    requests.emplace_back(std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
     REQUIRE_THROWS(client.start_requests(std::move(requests), nullptr));
 }

--- a/test/test_client.cpp
+++ b/test/test_client.cpp
@@ -9,10 +9,11 @@ TEST_CASE("client Start event loop, then stop and add a request.")
     auto request =
         lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
-    REQUIRE(client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
-        REQUIRE(response.lift_status() == lift::lift_status::success);
-        REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
-    }));
+    REQUIRE_NOTHROW(
+        client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
+            REQUIRE(response.lift_status() == lift::lift_status::success);
+            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
+        }));
 
     request =
         lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
@@ -20,41 +21,95 @@ TEST_CASE("client Start event loop, then stop and add a request.")
     // Adding requests after stopping should return false that they cannot be started.
     client.stop();
 
-    REQUIRE_FALSE(
+    REQUIRE_NOTHROW(
         client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
-            REQUIRE(response.lift_status() == lift::lift_status::success);
-            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
+            REQUIRE(response.lift_status() == lift::lift_status::error_failed_to_start);
+            REQUIRE(response.status_code() == lift::http::status_code::http_500_internal_server_error);
         }));
 }
 
-TEST_CASE("client Start event loop, then stop and add multiple requests.")
+TEST_CASE("client Start event loop, then stop and add multiple requests futures.")
 {
     lift::client client{};
 
-    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests1;
-    requests1.emplace_back(std::make_pair(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}),
-        [&](std::unique_ptr<lift::request>, lift::response response) {
-            REQUIRE(response.lift_status() == lift::lift_status::success);
-            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
-        }));
+    std::vector<lift::request_ptr> requests1;
+    requests1.emplace_back(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
-    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests2;
-    requests2.emplace_back(std::make_pair(
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}),
-        [&](std::unique_ptr<lift::request>, lift::response response) {
-            REQUIRE(response.lift_status() == lift::lift_status::success);
-            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
-        }));
+    std::vector<lift::request_ptr> requests2;
+    requests2.emplace_back(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
 
-    REQUIRE(client.start_requests(std::move(requests1)));
+    auto futures1 = client.start_requests(std::move(requests1));
     client.stop();
-    REQUIRE_FALSE(client.start_requests(std::move(requests2)));
+    auto futures2 = client.start_requests(std::move(requests2));
+
+    for (auto& f : futures1)
+    {
+        auto [req, rep] = f.get();
+        REQUIRE(rep.lift_status() == lift::lift_status::success);
+        REQUIRE(rep.status_code() == lift::http::status_code::http_200_ok);
+    }
+
+    for (auto& f : futures2)
+    {
+        auto [req, rep] = f.get();
+        REQUIRE(rep.lift_status() == lift::lift_status::error_failed_to_start);
+        REQUIRE(rep.status_code() == lift::http::status_code::http_500_internal_server_error);
+    }
+}
+
+TEST_CASE("client Start event loop, then stop and add multiple requests callback.")
+{
+    lift::client client{};
+
+    auto callback1 = [&](std::unique_ptr<lift::request>, lift::response response) {
+        REQUIRE(response.lift_status() == lift::lift_status::success);
+        REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
+    };
+
+    auto callback2 = [&](std::unique_ptr<lift::request>, lift::response response) {
+        REQUIRE(response.lift_status() == lift::lift_status::error_failed_to_start);
+        REQUIRE(response.status_code() == lift::http::status_code::http_500_internal_server_error);
+    };
+
+    std::vector<lift::request_ptr> requests1;
+    requests1.emplace_back(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+
+    std::vector<lift::request_ptr> requests2;
+    requests2.emplace_back(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+
+    client.start_requests(std::move(requests1), callback1);
+    client.stop();
+    client.start_requests(std::move(requests2), callback2);
 }
 
 TEST_CASE("client Provide nullptr request")
 {
     lift::client client{};
 
-    REQUIRE_FALSE(client.start_request(nullptr, nullptr));
+    REQUIRE_THROWS(client.start_request(nullptr, nullptr));
+}
+
+TEST_CASE("client Provide nullptr lambda functor")
+{
+    lift::client client{};
+
+    auto request =
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+
+    REQUIRE_THROWS(client.start_request(std::move(request), nullptr));
+}
+
+TEST_CASE("client Provide nullptr lambda functor for batch requests")
+{
+    lift::client client{};
+
+    std::vector<lift::request_ptr> requests{};
+    requests.emplace_back(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}));
+
+    REQUIRE_THROWS(client.start_requests(std::move(requests), nullptr));
 }

--- a/test/test_client.cpp
+++ b/test/test_client.cpp
@@ -6,47 +6,42 @@ TEST_CASE("client Start event loop, then stop and add a request.")
 {
     lift::client client{};
 
-    auto request = lift::request::make_unique(
-        "http://" + nginx_hostname + ":" + nginx_port_str + "/",
-        std::chrono::seconds{60},
-        [&](std::unique_ptr<lift::request>, lift::response response) {
-            REQUIRE(response.lift_status() == lift::lift_status::success);
-            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
-        });
+    auto request =
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
-    REQUIRE(client.start_request(std::move(request)));
+    REQUIRE(client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
+        REQUIRE(response.lift_status() == lift::lift_status::success);
+        REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
+    }));
 
-    request = lift::request::make_unique(
-        "http://" + nginx_hostname + ":" + nginx_port_str + "/",
-        std::chrono::seconds{60},
-        [&](std::unique_ptr<lift::request>, lift::response response) {
-            REQUIRE(response.lift_status() == lift::lift_status::success);
-            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
-        });
+    request =
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
     // Adding requests after stopping should return false that they cannot be started.
     client.stop();
 
-    REQUIRE_FALSE(client.start_request(std::move(request)));
+    REQUIRE_FALSE(
+        client.start_request(std::move(request), [&](std::unique_ptr<lift::request>, lift::response response) {
+            REQUIRE(response.lift_status() == lift::lift_status::success);
+            REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
+        }));
 }
 
 TEST_CASE("client Start event loop, then stop and add multiple requests.")
 {
     lift::client client{};
 
-    std::vector<lift::request_ptr> requests1;
-    requests1.emplace_back(lift::request::make_unique(
-        "http://" + nginx_hostname + ":" + nginx_port_str + "/",
-        std::chrono::seconds{60},
+    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests1;
+    requests1.emplace_back(std::make_pair(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}),
         [&](std::unique_ptr<lift::request>, lift::response response) {
             REQUIRE(response.lift_status() == lift::lift_status::success);
             REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
         }));
 
-    std::vector<lift::request_ptr> requests2;
-    requests2.emplace_back(lift::request::make_unique(
-        "http://" + nginx_hostname + ":" + nginx_port_str + "/",
-        std::chrono::seconds{60},
+    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests2;
+    requests2.emplace_back(std::make_pair(
+        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60}),
         [&](std::unique_ptr<lift::request>, lift::response response) {
             REQUIRE(response.lift_status() == lift::lift_status::success);
             REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
@@ -61,5 +56,5 @@ TEST_CASE("client Provide nullptr request")
 {
     lift::client client{};
 
-    REQUIRE_FALSE(client.start_request(nullptr));
+    REQUIRE_FALSE(client.start_request(nullptr, nullptr));
 }

--- a/test/test_proxy.cpp
+++ b/test/test_proxy.cpp
@@ -18,7 +18,7 @@ TEST_CASE("proxy")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.20.1");
         }
         else if (header.name() == "content-length")
         {
@@ -51,7 +51,7 @@ TEST_CASE("proxy Basic Auth")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.20.1");
         }
         else if (header.name() == "content-length")
         {
@@ -84,7 +84,7 @@ TEST_CASE("proxy Any Auth")
     {
         if (header.name() == "server")
         {
-            REQUIRE(header.value() == "nginx/1.18.0");
+            REQUIRE(header.value() == "nginx/1.20.1");
         }
         else if (header.name() == "content-length")
         {

--- a/test/test_resolve_host.cpp
+++ b/test/test_resolve_host.cpp
@@ -33,8 +33,8 @@ TEST_CASE("resolve_host client")
     };
 
     std::vector<lift::request_ptr> requests;
-    requests.emplace_back(lift::request::make_unique("testhostname:" + nginx_port_str, std::chrono::seconds{60}));
-    requests.emplace_back(lift::request::make_unique("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}));
+    requests.emplace_back(std::make_unique<lift::request>("testhostname:" + nginx_port_str, std::chrono::seconds{60}));
+    requests.emplace_back(std::make_unique<lift::request>("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}));
 
     client.start_requests(std::move(requests), on_complete);
 }

--- a/test/test_resolve_host.cpp
+++ b/test/test_resolve_host.cpp
@@ -32,11 +32,11 @@ TEST_CASE("resolve_host client")
         REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
     };
 
-    std::vector<lift::request_ptr> requests;
-    requests.emplace_back(
-        lift::request::make_unique("testhostname:" + nginx_port_str, std::chrono::seconds{60}, on_complete));
-    requests.emplace_back(
-        lift::request::make_unique("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}, on_complete));
+    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests;
+    requests.emplace_back(std::make_pair(
+        lift::request::make_unique("testhostname:" + nginx_port_str, std::chrono::seconds{60}), on_complete));
+    requests.emplace_back(std::make_pair(
+        lift::request::make_unique("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}), on_complete));
 
     REQUIRE(client.start_requests(std::move(requests)));
 }

--- a/test/test_resolve_host.cpp
+++ b/test/test_resolve_host.cpp
@@ -32,11 +32,9 @@ TEST_CASE("resolve_host client")
         REQUIRE(response.status_code() == lift::http::status_code::http_200_ok);
     };
 
-    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests;
-    requests.emplace_back(std::make_pair(
-        lift::request::make_unique("testhostname:" + nginx_port_str, std::chrono::seconds{60}), on_complete));
-    requests.emplace_back(std::make_pair(
-        lift::request::make_unique("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}), on_complete));
+    std::vector<lift::request_ptr> requests;
+    requests.emplace_back(lift::request::make_unique("testhostname:" + nginx_port_str, std::chrono::seconds{60}));
+    requests.emplace_back(lift::request::make_unique("herpderp.com:" + nginx_port_str, std::chrono::seconds{60}));
 
-    REQUIRE(client.start_requests(std::move(requests)));
+    client.start_requests(std::move(requests), on_complete);
 }

--- a/test/test_share.cpp
+++ b/test/test_share.cpp
@@ -40,11 +40,11 @@ TEST_CASE("share client synchronous")
 
     lift::client client2{lift::client::options{.share = lift_share_ptr}};
 
-    auto request1 =
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+    auto request1 = std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
-    auto request2 =
-        lift::request::make_unique("http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
+    auto request2 = std::make_unique<lift::request>(
+        "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{60});
 
     client1.start_request(std::move(request1), [&](std::unique_ptr<lift::request>, lift::response response) {
         REQUIRE(response.lift_status() == lift::lift_status::success);
@@ -85,7 +85,7 @@ TEST_CASE("share client overlapping requests")
 
         for (size_t i = 0; i < N_REQUESTS; ++i)
         {
-            auto request_ptr = lift::request::make_unique(
+            auto request_ptr = std::make_unique<lift::request>(
                 "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{5});
 
             client.start_request(std::move(request_ptr), [&](std::unique_ptr<lift::request>, lift::response response) {

--- a/test/test_timesup.cpp
+++ b/test/test_timesup.cpp
@@ -20,43 +20,25 @@ TEST_CASE("Timesup single request")
         REQUIRE(response.num_connects() == 0);
         REQUIRE(response.num_redirects() == 0);
     });
-
-    while (!client.empty())
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
-    }
 }
 
 TEST_CASE("Timesup two requests")
 {
     lift::client client{lift::client::options{.connect_timeout = std::chrono::seconds{1}}};
 
-    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests{};
+    std::vector<lift::request_ptr> requests{};
 
-    requests.push_back(std::make_pair(
-        lift::request::make_unique(
-            "http://www.reddit.com", // should be slow enough /shrug
-            std::chrono::milliseconds{25}),
-        [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
-            REQUIRE(response.lift_status() == lift::lift_status::timeout);
-            REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
-            REQUIRE(response.total_time() == std::chrono::milliseconds{25});
-        }));
+    auto callback = [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
+        REQUIRE(response.lift_status() == lift::lift_status::timeout);
+        REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
+        REQUIRE(
+            (response.total_time() == std::chrono::milliseconds{25} ||
+             response.total_time() == std::chrono::milliseconds{50}));
+    };
 
-    requests.push_back(std::make_pair(
-        lift::request::make_unique(
-            "http://www.reddit.com", // should be slow enough /shrug
-            std::chrono::milliseconds{50}),
-        [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
-            REQUIRE(response.lift_status() == lift::lift_status::timeout);
-            REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
-            REQUIRE(response.total_time() == std::chrono::milliseconds{50});
-        }));
+    // should be slow enough /shrug
+    requests.push_back(lift::request::make_unique("http://www.reddit.com", std::chrono::milliseconds{25}));
+    requests.push_back(lift::request::make_unique("http://www.reddit.com", std::chrono::milliseconds{50}));
 
     client.start_requests(std::move(requests));
-
-    while (!client.empty())
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
-    }
 }

--- a/test/test_timesup.cpp
+++ b/test/test_timesup.cpp
@@ -9,7 +9,7 @@ TEST_CASE("Timesup single request")
 {
     lift::client client{lift::client::options{.connect_timeout = std::chrono::seconds{1}}};
 
-    auto r = lift::request::make_unique(
+    auto r = std::make_unique<lift::request>(
         "http://www.reddit.com", // should be slow enough /shrug
         std::chrono::milliseconds{25});
 
@@ -37,8 +37,8 @@ TEST_CASE("Timesup two requests")
     };
 
     // should be slow enough /shrug
-    requests.push_back(lift::request::make_unique("http://www.reddit.com", std::chrono::milliseconds{25}));
-    requests.push_back(lift::request::make_unique("http://www.reddit.com", std::chrono::milliseconds{50}));
+    requests.push_back(std::make_unique<lift::request>("http://www.reddit.com", std::chrono::milliseconds{25}));
+    requests.push_back(std::make_unique<lift::request>("http://www.reddit.com", std::chrono::milliseconds{50}));
 
     client.start_requests(std::move(requests));
 }

--- a/test/test_timesup.cpp
+++ b/test/test_timesup.cpp
@@ -11,16 +11,15 @@ TEST_CASE("Timesup single request")
 
     auto r = lift::request::make_unique(
         "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{25},
-        [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
-            REQUIRE(response.lift_status() == lift::lift_status::timeout);
-            REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
-            REQUIRE(response.total_time() == std::chrono::milliseconds{25});
-            REQUIRE(response.num_connects() == 0);
-            REQUIRE(response.num_redirects() == 0);
-        });
+        std::chrono::milliseconds{25});
 
-    client.start_request(std::move(r));
+    client.start_request(std::move(r), [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
+        REQUIRE(response.lift_status() == lift::lift_status::timeout);
+        REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
+        REQUIRE(response.total_time() == std::chrono::milliseconds{25});
+        REQUIRE(response.num_connects() == 0);
+        REQUIRE(response.num_redirects() == 0);
+    });
 
     while (!client.empty())
     {
@@ -32,20 +31,22 @@ TEST_CASE("Timesup two requests")
 {
     lift::client client{lift::client::options{.connect_timeout = std::chrono::seconds{1}}};
 
-    std::vector<lift::request_ptr> requests{};
+    std::vector<std::pair<lift::request_ptr, lift::request::async_callback_type>> requests{};
 
-    requests.push_back(lift::request::make_unique(
-        "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{25},
+    requests.push_back(std::make_pair(
+        lift::request::make_unique(
+            "http://www.reddit.com", // should be slow enough /shrug
+            std::chrono::milliseconds{25}),
         [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
             REQUIRE(response.lift_status() == lift::lift_status::timeout);
             REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);
             REQUIRE(response.total_time() == std::chrono::milliseconds{25});
         }));
 
-    requests.push_back(lift::request::make_unique(
-        "http://www.reddit.com", // should be slow enough /shrug
-        std::chrono::milliseconds{50},
+    requests.push_back(std::make_pair(
+        lift::request::make_unique(
+            "http://www.reddit.com", // should be slow enough /shrug
+            std::chrono::milliseconds{50}),
         [](std::unique_ptr<lift::request> rh, lift::response response) -> void {
             REQUIRE(response.lift_status() == lift::lift_status::timeout);
             REQUIRE(response.status_code() == lift::http::status_code::http_504_gateway_timeout);

--- a/test/test_user_data_request.cpp
+++ b/test/test_user_data_request.cpp
@@ -30,19 +30,17 @@ TEST_CASE("User data")
 
     auto req1 = std::make_unique<lift::request>(
         "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{1});
-    req1->on_complete_handler([request_id](lift::request_ptr request, lift::response response) {
+    client.start_request(std::move(req1), [request_id](lift::request_ptr request, lift::response response) {
         user_data_on_complete(std::move(request), std::move(response), request_id, 100.5);
     });
-    client.start_request(std::move(req1));
 
     request_id = 2;
 
     auto req2 = std::make_unique<lift::request>(
         "http://" + nginx_hostname + ":" + nginx_port_str + "/", std::chrono::seconds{1});
-    req2->on_complete_handler([request_id](lift::request_ptr request, lift::response response) {
+    client.start_request(std::move(req2), [request_id](lift::request_ptr request, lift::response response) {
         user_data_on_complete(std::move(request), std::move(response), request_id, 1234.567);
     });
-    client.start_request(std::move(req2));
 
     while (!client.empty())
     {


### PR DESCRIPTION
Major workaround for std::function with a move only type while avoiding additional mallocs.