### PR TITLE
Add lift::client_pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBLIFTHTTP_SOURCE_FILES
     inc/lift/impl/copy_util.hpp
     inc/lift/impl/pragma.hpp
 
+    inc/lift/client_pool.hpp src/client_pool.cpp
     inc/lift/client.hpp src/client.cpp
     inc/lift/const.hpp
     inc/lift/escape.hpp src/escape.cpp

--- a/inc/lift/client.hpp
+++ b/inc/lift/client.hpp
@@ -101,7 +101,7 @@ public:
      * @return Gets the number of active HTTP requests currently running.  This includes
      *         the number of pending requests that haven't been started yet (if any).
      */
-    [[nodiscard]] auto size() const -> uint64_t { return m_active_request_count.load(std::memory_order_acquire); }
+    [[nodiscard]] auto size() const -> std::size_t { return m_active_request_count.load(std::memory_order_acquire); }
 
     /**
      * @return True if there are no requests pending or executing.
@@ -218,7 +218,7 @@ private:
     /// Set to true if the client is currently shutting down.
     std::atomic<bool> m_is_stopping{false};
     /// The active number of requests running.
-    std::atomic<uint64_t> m_active_request_count{0};
+    std::atomic<std::size_t> m_active_request_count{0};
 
     /// The UV event loop to drive libcurl.
     uv_loop_t m_uv_loop{};

--- a/inc/lift/client_pool.hpp
+++ b/inc/lift/client_pool.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "lift/client.hpp"
+
+#include <vector>
+
+namespace lift
+{
+
+class client_pool
+{
+public:
+    using on_thread_callback_type = std::function<void()>;
+
+    struct options
+    {
+        /// @brief The number of clients to spin up in the pool.
+        std::size_t client_count{2};
+        /// @brief If this functor is provided it is called on each client's
+        ///        background thread when it starts and stops.
+        on_thread_callback_type on_thread_callback{nullptr};
+    };
+
+    explicit client_pool(options opts = options{.client_count = 2, .on_thread_callback = nullptr});
+
+    ~client_pool();
+
+    client_pool(const client_pool&) = delete;
+    client_pool(client_pool&&);
+    auto operator=(const client_pool&) noexcept -> client_pool& = delete;
+    auto operator=(client_pool&&) noexcept -> client_pool&;
+
+    auto stop() -> void;
+
+    [[nodiscard]] auto size() const -> std::size_t;
+    [[nodiscard]] auto empty() const -> bool { return size() == 0; }
+
+    [[nodiscard]] auto start_request(request_ptr&& request_ptr) -> request::async_future_type;
+    auto               start_request(request_ptr&& request_ptr, request::async_callback_type callback) -> void;
+
+    template<typename container_type>
+    auto start_requests(container_type&& requests) -> std::vector<request::async_future_type>
+    {
+        std::vector<request::async_future_type> futures{};
+        futures.reserve(std::size(requests));
+
+        for (auto& request_ptr : requests)
+        {
+            if (request_ptr != nullptr)
+            {
+                auto index = client_index_advance();
+                futures.emplace_back(m_clients[index]->start_request(std::move(request_ptr)));
+            }
+        }
+
+        return futures;
+    }
+
+    template<typename container_type>
+    auto start_requests(container_type&& requests, request::async_callback_type callback) -> void
+    {
+        if (callback == nullptr)
+        {
+            throw std::runtime_error{"lift::client_pool::start_requests (callback) The callback cannot be nullptr."};
+        }
+
+        for (auto& request_ptr : requests)
+        {
+            if (request_ptr != nullptr)
+            {
+                auto index = client_index_advance();
+                m_clients[index]->start_request(std::move(request_ptr, callback));
+            }
+        }
+    }
+
+private:
+    std::atomic<std::size_t>                   m_index{0};
+    std::vector<std::unique_ptr<lift::client>> m_clients{};
+    on_thread_callback_type                    m_on_thread_callback{nullptr};
+
+    auto client_index_advance() -> std::size_t
+    {
+        return m_index.fetch_add(1, std::memory_order_acq_rel) % m_clients.size();
+    }
+};
+
+} // namespace lift

--- a/inc/lift/lift.hpp
+++ b/inc/lift/lift.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "lift/client.hpp"
+#include "lift/client_pool.hpp"
 #include "lift/const.hpp"
 #include "lift/escape.hpp"
 #include "lift/executor.hpp"

--- a/src/client_pool.cpp
+++ b/src/client_pool.cpp
@@ -1,0 +1,60 @@
+#include "lift/client_pool.hpp"
+
+namespace lift
+{
+
+client_pool::client_pool(options opts) : m_on_thread_callback(opts.on_thread_callback)
+{
+    for (std::size_t i = 0; i < opts.client_count; ++i)
+    {
+        auto options = lift::client::options{.on_thread_callback = m_on_thread_callback};
+
+        m_clients.emplace_back(std::make_unique<lift::client>(options));
+    }
+}
+
+client_pool::~client_pool()
+{
+    stop();
+}
+
+client_pool::client_pool(client_pool&& other)
+{
+    m_index              = other.m_index.exchange(0);
+    m_clients            = std::move(other.m_clients);
+    m_on_thread_callback = other.m_on_thread_callback;
+}
+
+auto client_pool::stop() -> void
+{
+    for (auto& client : m_clients)
+    {
+        client->stop();
+    }
+}
+
+auto client_pool::size() const -> std::size_t
+{
+    std::size_t total{0};
+
+    for (const auto& client : m_clients)
+    {
+        total += client->size();
+    }
+
+    return total;
+}
+
+auto client_pool::start_request(request_ptr&& request_ptr) -> request::async_future_type
+{
+    auto index = client_index_advance();
+    return m_clients[index]->start_request(std::move(request_ptr));
+}
+
+auto client_pool::start_request(request_ptr&& request_ptr, request::async_callback_type callback) -> void
+{
+    auto index = client_index_advance();
+    m_clients[index]->start_request(std::move(request_ptr), std::move(callback));
+}
+
+} // namespace lift


### PR DESCRIPTION
This structure allows for the user to spin up N clients that will round robin handle requests that are started.

Updated the benchmark.cpp file to use the new lift::client_pool instead of spinning up N lift::client's into a vector. This test is _probably_ slower since requests will now bounce around to different threads, but I think this is worth it with the ease of use of the lift::client_pool.

Closes #157