### PR TITLE
Segfault with client when using modern version of curl

### DIFF
--- a/examples/async_simple.cpp
+++ b/examples/async_simple.cpp
@@ -22,7 +22,7 @@ int main()
 {
     using namespace std::chrono_literals;
 
-    std::vector<std::string> urls = {"http://www.example.com", "http://www.google.com", "http://www.reddit.com"};
+    std::vector<std::string> urls = {"http://www.example.com", "https://www.google.com", "http://www.reddit.com"};
 
     lift::client client{};
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -145,6 +145,8 @@ client::~client()
         std::this_thread::sleep_for(1ms);
     }
 
+    curl_multi_cleanup(m_cmh);
+
     // This breaks the main UV_RUN_DEFAULT loop.
     uv_stop(&m_uv_loop);
     // This tells the loop to cleanup all its resources.
@@ -161,7 +163,6 @@ client::~client()
     m_background_thread.join();
     m_executors.clear();
 
-    curl_multi_cleanup(m_cmh);
     global_cleanup();
 }
 


### PR DESCRIPTION
curl_multi_cleanup appears to call back through its resources on cleanup now with a more modern version of the library, to pervent this from segfaulting the curl_multi_cleanup needs to happen before any of the libuv resources are destroyed in the ~client().

Closes #172