### PR TITLE
added shared lib build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set(LIBLIFTHTTP_SOURCE_FILES
     inc/lift/response.hpp src/response.cpp
 )
 
-add_library(${PROJECT_NAME} STATIC ${LIBLIFTHTTP_SOURCE_FILES})
+add_library(${PROJECT_NAME} ${LIBLIFTHTTP_SOURCE_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 


### PR DESCRIPTION
a static lib is build when no 'type' parameter is supplied for the 'add_library' call
https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html#variable:BUILD_SHARED_LIBS